### PR TITLE
Change title to more specific "Developing ManageIQ"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Developing ManageIQ
+## ManageIQ Developer Documentation
 
 * [Coding Style and Standards](coding_style_and_standards.md)
 * [Architecture](architecture.md)
 * [Roadmap](roadmap.md)
 * [REST API](rest_api.md)
 
-# License
+## License
 
 ![Creative Commons License](http://i.creativecommons.org/l/by/3.0/88x31.png)
 This work is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US)


### PR DESCRIPTION
The new header matches the corresponding "Using ManageIQ" in manageiq.org/documentation
