### PR TITLE
REST API Guide update to reflect Service Requests as sub-collection

### DIFF
--- a/rest_api/examples/queries.md
+++ b/rest_api/examples/queries.md
@@ -60,6 +60,12 @@ GET /api/services/1/tags?expand=resources
 GET /api/service_catalogs/1?expand=service_templates
 ```
 
+### Get services requests created from a specific template and get details on all related request tasks.
+
+```
+GET /api/service_templates/25/service_requests?expand=resources,request_tasks
+```
+
 ### Get a specific provision request with expanded details on the associated provision request tasks
 
 ```

--- a/rest_api/reference.md
+++ b/rest_api/reference.md
@@ -80,6 +80,10 @@ features please refer to the [Design Specification](./design.md).
 | Service Templates        | /api/\<collection\>/\<id\>/service_templates                     |
 | Tags                     | /api/\<collection\>/\<id\>/tags                                  |
 | | |
+| Service Requests         | /api/service_templates/\<id\>/service_requests                   |
+| | |
+| Service Request Tasks    | /api/service_requests/\<id\>/request_tasks                       |
+|                          | /api/service_requests/\<id\>/tasks  (*alias of request_tasks*)   |
 | Automation Request Tasks | /api/automation_requests/\<id\>/request_tasks                    |
 |                          | /api/automation_requests/\<id\>/tasks (*alias of request_tasks*) |
 | Provision Request Tasks  | /api/provision_requests/\<id\>/request_tasks                     |


### PR DESCRIPTION
- Supporting /api/service_templates/#/service_requests
- Supporting /api/service_templates/#/service_requests?expand=resources,request_tasks
- Supporting /api/service_requests/#/request_tasks (or tasks)

Depends on: https://github.com/ManageIQ/manageiq/pull/312
