### PR TITLE
Markdown fixes for developer setup

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -5,13 +5,13 @@
   1.  Install packages
 
       ```bash
-      sudo yum -y install xchat                                                         # For IRC
-      sudo yum -y install adobe-source-code-pro-fonts                                   # Nicer fonts to work with
-      sudo yum -y install git-all                                                       # Git and components
-      sudo yum -y install memcached                                                     # Memcached for the session store
-      sudo yum -y install postgresql postgresql-libs postgresql-devel postgresql-server # PostgreSQL Database server and to build 'pg' Gem
-      sudo yum -y install libxml2-devel libxslt-devel                                     # For Nokogiri Gem
-      sudo yum -y install gcc-c++                                                       # For event-machine Gem
+      sudo yum -y install xchat                              # For IRC
+      sudo yum -y install adobe-source-code-pro-fonts        # Nicer fonts to work with
+      sudo yum -y install git-all                            # Git and components
+      sudo yum -y install memcached                          # Memcached for the session store
+      sudo yum -y install postgresql-devel postgresql-server # PostgreSQL Database server and to build 'pg' Gem
+      sudo yum -y install libxml2-devel libxslt-devel        # For Nokogiri Gem
+      sudo yum -y install gcc-c++                            # For event-machine Gem
       ```
 
   2.  Enable Memcached


### PR DESCRIPTION
This branch contains several Markdown-related fixes for the developer setup instructions, including:
1. Proper order of headings
2. Alignment of pre blocks within bulleted lists
3. Unordered list under Fedora changed into an ordered list (as it contains steps
4. Removal of `postgresql` and `postgresql-libs` as they're pulled in as dependencies anyway — this allows all the lines in that pre block to be shorter (as comments are aligned), so that lines do not wrap
