### PR TITLE
Add doc of the providers database architecture

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -99,6 +99,8 @@
 
 ## Database Architecture
 
+[Detailed Providers database architecturee](architecture/providers_database_architecture.md)
+
 * Schema Layout
   * 64-bit ids
 * MiqQueue

--- a/architecture/providers_database_architecture.md
+++ b/architecture/providers_database_architecture.md
@@ -1,0 +1,74 @@
+# Providers database architecture
+
+All the providers are using the same model of the database on the
+background. This documentation describes each model, database
+structure with description of each field and ER-Diagram of each
+group, to show the relations of the models.
+
+## Inventory Models
+
+When creating new provider, these will be the models that should
+be filled with EMS_Refresh.
+
+* Cloud
+  * [CloudNetwork](providers_database_architecture/cloud_network.md)
+  * [CloudSubnet](providers_database_architecture/cloud_subnet.md)
+  * [CloudObjectStoreContainer](providers_database_architecture/cloud_object_store_container.md)
+  * [CloudObjectStoreObject](providers_database_architecture/cloud_object_store_object.md)
+  * [CloudResourceQuota](providers_database_architecture/cloud_resource_quota.md) (STI)
+    * CloudResourceQuotaOpenstack
+  * [CloudTenant](providers_database_architecture/cloud_tenant.md) (STI)
+    * CloudTenantOpenstack
+  * [CloudVolume](providers_database_architecture/cloud_volume.md) (STI)
+    * CloudVolumeAmazon
+    * CloudVolumeOpenstack
+  * [CloudVolumeSnapshot](providers_database_architecture/cloud_volume_snapshot.md) (STI)
+    * CloudVolumeSnapshotAmazon
+    * CloudVolumeSnapshotOpenstack
+* [VmOrTemplate](providers_database_architecture/vm_or_template.md) (STI)
+  * Vm
+    * VmInfra
+      * VmKvm
+      * VmMicrosoft
+      * VmRedhat
+      * VmVmware
+      * VmXen
+    * VmCloud
+      * VmAmazon
+      * VmOpenstack
+  * MiqTemplate
+    * TemplateInfra
+      * TemplateKvm
+      * TemplateMicrosoft
+      * TemplateRedhat
+      * TemplateVmware
+      * TemplateXen
+    * TemplateCloud
+      * TemplateAmazon
+      * TemplateOpenstack
+* Orchestration
+  * [OrchestrationStack](providers_database_architecture/orchestration_stack.md)
+  * [OrchestrationStackOutput](providers_database_architecture/orchestration_stack_output.md)
+  * [OrchestrationStackParameter](providers_database_architecture/orchestration_stack_parameter.md)
+  * [OrchestrationStackResource](providers_database_architecture/orchestration_stack_resource.md)
+  * [OrchestrationTemplate](providers_database_architecture/orchestration_template.md)
+* [Host](providers_database_architecture/host.md) (STI)
+  * HostKvm
+  * HostMicrosoft
+  * HostRedhat
+  * HostVmware
+    * HostVmwareEsx
+* [AvailabilityZone](providers_database_architecture/availability_zone.md) (STI)
+  * AvailabilityZoneAmazon
+  * AvailabilityZoneOpenstack
+    * AvailabilityZoneOpenstackNull
+* [Flavor](providers_database_architecture/flavor.md) (STI)
+  * FlavorAmazon
+  * FlavorOpenstack
+* [SecurityGroup](providers_database_architecture/security_group.md) (STI)
+  * SecurityGroupAmazon
+  * SecurityGroupOpenstack
+
+## Metric Models
+
+## Event Models

--- a/architecture/providers_database_architecture/availability_zone.md
+++ b/architecture/providers_database_architecture/availability_zone.md
@@ -1,0 +1,15 @@
+# AvailabilityZone model documentation
+
+* Table: availability_zones
+* Used in: OpenStack, Amazon
+* STI models:
+  * AvailabilityZoneAmazon
+  * AvailabilityZoneOpenstack
+    * AvailabilityZoneOpenstackNull
+
+| Column  | Type      | Used in           | Comment |
+| ------- | --------- | ----------------- | ------- |
+| ems_id  | integer   | OpenStack, Amazon |         |
+| name    | string    | OpenStack, Amazon |         |
+| ems_ref | string    | OpenStack, Amazon |         |
+| type    | string    | OpenStack, Amazon | STI class |

--- a/architecture/providers_database_architecture/cloud_network.md
+++ b/architecture/providers_database_architecture/cloud_network.md
@@ -1,0 +1,18 @@
+# CloudNetwork model documentation
+
+A network is a virtual isolated layer-2 broadcast domain which is typically reserved to the tenant who created it, unless the network has been explicitly configured to be shared. Tenants can create multiple networks, until they reach the thresholds specified by per-tenant Quotas (see next chapter for more details). The network is the principal entity for the Neutron API. Ports and subnets must always be associated with a network. The following table describes the attributes of network objects. For each attribute, the CRUD column should be read as follows:
+
+* Table: cloud_networks
+* Used in: OpenStack
+
+| Column                 | Type      | Used in   | Comment |
+| ---------------------- | --------- | --------- | ------- |
+| name                   | string    | OpenStack | Name of the network |
+| ems_ref                | string    | OpenStack |         |
+| ems_id                 | integer   | OpenStack |         |
+| cidr                   | string    | OpenStack | Valid CIDR in the form <network_address>/<prefix> |
+| status                 | string    | OpenStack |         |
+| enabled                | boolean   | OpenStack |         |
+| external_facing        | boolean   | OpenStack |         |
+| cloud_tenant_id        | integer   | OpenStack | ForeignKey |
+| orchestration_stack_id | integer   | OpenStack | ForeignKey |

--- a/architecture/providers_database_architecture/cloud_object_store_container.md
+++ b/architecture/providers_database_architecture/cloud_object_store_container.md
@@ -1,0 +1,21 @@
+# CloudObjectStoreContainer model documentation
+
+Defines a namespace for objects. An object with the same name in two different containers represents two different objects. You can create any number of containers within an account.
+
+In addition to containing objects, you can also use the container to control access to objects by using an access control list (ACL). You cannot store an ACL with individual objects.
+
+In addition, you configure and control many other features, such as object versioning, at the container level
+
+You can bulk-delete up to 10,000 containers in a single request
+
+* Table: cloud_object_store_containers
+* Used in: OpenStack
+
+| Column          | Type      | Used in   | Comment |
+| --------------- | --------- | --------- | ------- |
+| ems_ref         | string    | OpenStack |         |
+| key             | string    | OpenStack |         |
+| object_count    | integer   | OpenStack | Number of the all objects inside of the container |
+| bytes           | integer   | OpenStack | Size of the whole container in bytes |
+| ems_id          | integer   | OpenStack |         |
+| cloud_tenant_id | integer   | OpenStack | ForeignKey |

--- a/architecture/providers_database_architecture/cloud_object_store_object.md
+++ b/architecture/providers_database_architecture/cloud_object_store_object.md
@@ -1,0 +1,21 @@
+# CloudObjectStoreObject model documentation
+
+Stores data content, such as documents, images, and so on. You can also store custom metadata with an object.
+
+Store an unlimited number of objects. Each object can be as large as 5 GB, which is the default. You can configure the maximum object size.
+
+
+* Table: cloud_object_store_objects
+* Used in: OpenStack
+
+| Column                          | Type      | Used in   | Comment |
+| ------------------------------- | --------- | --------- | ------- |
+| ems_ref                         | string    | OpenStack |         |
+| etag                            | string    | OpenStack | For objects smaller than 5 GB, this value is the MD5 checksum of the object content. The value is not quoted. <br> For manifest objects, this value is the MD5 checksum of the concatenated string of MD5 checksums and ETags for each of the segments in the manifest, and not the MD5 checksum of the content that was downloaded. Also the value is enclosed in double-quote characters. <br> You are strongly recommended to compute the MD5 checksum of the response body as it is received and compare this value with the one in the ETag header. If they differ, the content was corrupted, so retry the operation. |
+| key                             | string    | OpenStack |         |
+| content_type                    | string    | OpenStack | The MIME type of the object. |
+| content_length                  | integer   | OpenStack | The length of the object content in the response body, in bytes. |
+| last_modified                   | datetime  | OpenStack | The date and time that the object was created or the last time that the metadata was changed. |
+| ems_id                          | integer   | OpenStack |         |
+| cloud_tenant_id                 | integer   | OpenStack | ForeignKey |
+| cloud_object_store_container_id | integer   | OpenStack | ForeignKey |

--- a/architecture/providers_database_architecture/cloud_resource_quota.md
+++ b/architecture/providers_database_architecture/cloud_resource_quota.md
@@ -1,0 +1,22 @@
+# CloudResourceQuota model documentation
+
+To prevent system capacities from being exhausted without notification, you can set up quotas. Quotas are operational limits. For example, the number of gigabytes allowed for each tenant can be controlled so that cloud resources are optimized. Quotas can be enforced at both the tenant (or project) and the tenant-user level.
+
+For OpenStack, list of available quotas can be found here http://docs.openstack.org/user-guide-admin/content/cli_set_quotas.html
+Using the command-line interface, you can manage quotas for the OpenStack Compute service, the OpenStack Block Storage service, and the OpenStack Networking service.
+
+* Table: cloud_resource_quotas
+* Used in: OpenStack
+* STI models: CloudResourceQuotaOpenstack
+
+| Column          | Type      | Used in   | Comment |
+| ----------------| --------- | --------- | ------- |
+| ems_ref         | string    | OpenStack |         |
+| service_name    | string    | OpenStack | Name of the service (e.g. Compute) |
+| name            | string    | OpenStack | Name of the quota |
+| value           | integer   | OpenStack | Value of the quota |
+| type            | string    | OpenStack | STI class |
+| ems_id          | integer   | OpenStack |         |
+| cloud_tenant_id | integer   | OpenStack | ForeignKey |
+| created_at      | datetime  | OpenStack |         |
+| updated_at      | datetime  | OpenStack |         |

--- a/architecture/providers_database_architecture/cloud_subnet.md
+++ b/architecture/providers_database_architecture/cloud_subnet.md
@@ -1,0 +1,21 @@
+# CloudSubnet model documentation
+
+A subnet represents an IP address block that can be used for assigning IP addresses to virtual instances. Each subnet must have a CIDR and must be associated with a network. IPs can be either selected from the whole subnet CIDR, or from "allocation pools" that can be specified by the user.
+
+A subnet can also optionally have a gateway, a list of DNS name servers, and host routes. All this information will then be pushed to instances whose interfaces are associated with the subnet.
+
+* Table: cloud_subnets
+* Used in: OpenStack
+
+| Column               | Type      | Used in   | Comment |
+| -------------------- | --------- | --------- | ------- |
+| name                 | string    | OpenStack |         |
+| ems_ref              | string    | OpenStack |         |
+| ems_id               | integer   | OpenStack |         |
+| availability_zone_id | integer   | OpenStack | ForeignKey |
+| cloud_network_id     | integer   | OpenStack | ForeignKey |
+| cidr                 | string    | OpenStack | Valid CIDR in the form <network_address>/<prefix> |
+| status               | string    | OpenStack |         |
+| dhcp_enabled         | boolean   | OpenStack | { true or false } |
+| gateway              | string    | OpenStack | Valid IP address or null |
+| network_protocol     | string    | OpenStack | IP version { ipv4 or ipv6 } |

--- a/architecture/providers_database_architecture/cloud_tenant.md
+++ b/architecture/providers_database_architecture/cloud_tenant.md
@@ -1,0 +1,18 @@
+# CloudTenant model documentation
+
+A container used to group or isolate resources and/or identity objects. Depending on the service operator, a tenant can map to a customer, account, organization, or project.
+
+* Table: cloud_tenants
+* Used in: OpenStack
+* STI models: CloudTenantOpenstack
+
+| Column      | Type      | Used in   | Comment |
+| ------------| --------- | --------- | ------- |
+| name        | string    | OpenStack |         |
+| description | string    | OpenStack |         |
+| enabled     | boolean   | OpenStack |         |
+| ems_ref     | string    | OpenStack |         |
+| ems_id      | integer   | OpenStack |         |
+| created_at  | datetime  | OpenStack |         |
+| updated_at  | datetime  | OpenStack |         |
+| type        | string    | OpenStack | STI class |

--- a/architecture/providers_database_architecture/cloud_volume.md
+++ b/architecture/providers_database_architecture/cloud_volume.md
@@ -1,0 +1,23 @@
+# CloudVolume model documentation
+
+A volume is a detachable block storage device. You can think of it as a USB hard drive. You can attach a volume to one instance at a time.
+
+* Table: cloud_volumes
+* Used in: OpenStack, Amazon
+* STI models: CloudVolumeAmazon, CloudVolumeOpenstack
+
+| Column                   | Type      | Used in           | Comment |
+| ------------------------ | --------- | ----------------- | ------- |
+| type                     | string    | OpenStack, Amazon | STI class |
+| ems_ref                  | string    | OpenStack, Amazon |         |
+| size                     | integer   | OpenStack, Amazon | The size of the volume, in GBs |
+| ems_id                   | integer   | OpenStack, Amazon |         |
+| availability_zone_id     | integer   | OpenStack, Amazon | ForeignKey |
+| cloud_volume_snapshot_id | integer   | OpenStack, Amazon | ForeignKey |
+| name                     | string    | OpenStack, Amazon | The volume name |
+| status                   | string    | OpenStack, Amazon | Status of the volume |
+| description              | string    | OpenStack, Amazon | The volume description |
+| volume_type              | string    | OpenStack, Amazon | The associated volume type |
+| bootable                 | boolean   | OpenStack, Amazon | Enables or disables the bootable attribute. You can boot an instance from a bootable volume. |
+| creation_time            | datetime  | OpenStack, Amazon | Date and time when the volume was created |
+| cloud_tenant_id          | integer   | OpenStack, Amazon | ForeignKey |

--- a/architecture/providers_database_architecture/cloud_volume_snapshot.md
+++ b/architecture/providers_database_architecture/cloud_volume_snapshot.md
@@ -1,0 +1,20 @@
+# CloudVolumeSnapshot model documentation
+
+A snapshot is a point in time copy of the data that a volume contains.
+
+* Table: cloud_volume_snapshots
+* Used in: OpenStack, Amazon
+* STI models: CloudVolumeSnapshotAmazon, CloudVolumeSnapshotOpenstack
+
+| Column          | Type      | Used in           | Comment |
+| --------------- | --------- | ----------------- | ------- |
+| type            | string    | OpenStack, Amazon | STI class |
+| ems_ref         | string    | OpenStack, Amazon |         |
+| ems_id          | integer   | OpenStack, Amazon |         |
+| cloud_volume_id | integer   | OpenStack, Amazon | ForeignKey |
+| name            | string    | OpenStack, Amazon | Name of the snapshot. Default==None. |
+| description     | string    | OpenStack, Amazon | Description of snapshot. Default==None. |
+| status          | string    | OpenStack, Amazon | Snapshot status |
+| creation_time   | datetime  | OpenStack, Amazon | Date and time when the snapshot was created |
+| size            | integer   | OpenStack, Amazon | The size of the volume, in GBs. |
+| cloud_tenant_id | integer   | OpenStack, Amazon | ForeignKey |

--- a/architecture/providers_database_architecture/flavor.md
+++ b/architecture/providers_database_architecture/flavor.md
@@ -1,0 +1,24 @@
+# Flavor model documentation
+
+List available flavors and get details for a specified flavor. A flavor is a hardware configuration for a server. Each flavor is a unique combination of disk space and memory capacity.
+
+* Table: flavors
+* Used in: OpenStack, Amazon
+* STI models: FlavorAmazon FlavorOpenstack
+
+| Column                   | Type      | Used in           | Comment |
+| ------------------------ | --------- | ----------------- | ------- |
+| ems_id                   | integer   | OpenStack, Amazon |         |
+| name                     | string    | OpenStack, Amazon | Name of the new flavor |
+| description              | string    | OpenStack, Amazon | Description of the flavor |
+| cpus                     | integer   | OpenStack, Amazon | Number of vcpus |
+| cpu_cores                | integer   |            Amazon |         |
+| memory                   | integer   | OpenStack, Amazon | Memory size in MB |
+| ems_ref                  | string    | OpenStack, Amazon |         |
+| type                     | string    | OpenStack, Amazon | STI class |
+| supports_32_bit          | boolean   |            Amazon |         |
+| supports_64_bit          | boolean   |            Amazon |         |
+| enabled                  | boolean   | OpenStack, Amazon |         |
+| supports_hvm             | boolean   |            Amazon |         |
+| supports_paravirtual     | boolean   |            Amazon |         |
+| block_storage_based_only | boolean   |            Amazon |         |

--- a/architecture/providers_database_architecture/host.md
+++ b/architecture/providers_database_architecture/host.md
@@ -1,0 +1,44 @@
+# Host model documentation
+
+* Table: hosts
+* Used in: Kvm, Microsoft, Redhat, Vmware
+* STI models:
+  * HostKvm
+  * HostMicrosoft
+  * HostRedhat
+  * HostVmware
+    * HostVmwareEsx
+
+| Column                  | Type      | Used in           | Comment |
+| ----------------------- | --------- | ----------------- | ------- |
+| name                    | string    |                   |         |
+| hostname                | string    |                   |         |
+| ipaddress               | string    |                   |         |
+| vmm_vendor              | string    |                   |         |
+| vmm_version             | string    |                   |         |
+| vmm_product             | string    |                   |         |
+| vmm_buildnumber         | string    |                   |         |
+| created_on              | datetime  |                   |         |
+| updated_on              | datetime  |                   |         |
+| guid                    | string    |                   |         |
+| ems_id                  | integer   |                   |         |
+| user_assigned_os        | string    |                   |         |
+| power_state             | string    |                   |         |
+| smart                   | integer   |                   |         |
+| settings                | string    |                   |         |
+| last_perf_capture_on    | datetime  |                   |         |
+| uid_ems                 | string    |                   |         |
+| connection_state        | string    |                   |         |
+| ssh_permit_root_login   | string    |                   |         |
+| ems_ref_obj             | string    |                   |         |
+| admin_disabled          | boolean   |                   |         |
+| service_tag             | string    |                   |         |
+| asset_tag               | string    |                   |         |
+| ipmi_address            | string    |                   |         |
+| mac_address             | string    |                   |         |
+| type                    | string    |                   | STI class |
+| failover                | boolean   |                   |         |
+| ems_ref                 | string    |                   |         |
+| hyperthreading          | boolean   |                   |         |
+| ems_cluster_id          | integer   |                   | ForeignKey |
+| next_available_vnc_port | integer   |                   |         |

--- a/architecture/providers_database_architecture/orchestration_stack.md
+++ b/architecture/providers_database_architecture/orchestration_stack.md
@@ -1,0 +1,17 @@
+# OrchestrationStack model documentation
+
+* Table: orchestration_stacks
+* Used in: OpenStack
+
+| Column                    | Type      | Used in           | Comment |
+| ------------------------- | --------- | ----------------- | ------- |
+| name                      | string    | OpenStack         | The name of the stack |
+| type                      | string    | OpenStack         | STI class |
+| description               | text      | OpenStack         | The description of the stack |
+| status                    | string    | OpenStack         | Status of the stack |
+| ems_ref                   | string    | OpenStack         |         |
+| ancestry                  | string    | OpenStack         |         |
+| ems_id                    | integer   | OpenStack         |         |
+| orchestration_template_id | integer   | OpenStack         | ForeignKey |
+| created_at                | datetime  | OpenStack         |         |
+| updated_at                | datetime  | OpenStack         |         |

--- a/architecture/providers_database_architecture/orchestration_stack_output.md
+++ b/architecture/providers_database_architecture/orchestration_stack_output.md
@@ -1,0 +1,11 @@
+# OrchestrationStackOutput model documentation
+
+* Table: orchestration_stack_outputs
+* Used in: OpenStack
+
+| Column       | Type      | Used in           | Comment |
+| ------------ | --------- | ----------------- | ------- |
+| key          | string    | OpenStack         | The key of the output |
+| value        | text      | OpenStack         | The value of the output |
+| description  | text      | OpenStack         | The description of the output |
+| stack_id     | integer   | OpenStack         | ForeignKey |

--- a/architecture/providers_database_architecture/orchestration_stack_parameter.md
+++ b/architecture/providers_database_architecture/orchestration_stack_parameter.md
@@ -1,0 +1,10 @@
+# OrchestrationStackParameter model documentation
+
+* Table: orchestration_stack_parameters
+* Used in: OpenStack
+
+| Column    | Type      | Used in           | Comment |
+| --------- | --------- | ----------------- | ------- |
+| name      | string    | OpenStack         | The name of the parameter |
+| value     | text      | OpenStack         | The value of the parameter |
+| stack_id  | integer   | OpenStack         | ForeignKey |

--- a/architecture/providers_database_architecture/orchestration_stack_resource.md
+++ b/architecture/providers_database_architecture/orchestration_stack_resource.md
@@ -1,0 +1,16 @@
+# OrchestrationStackResource model documentation
+
+* Table: orchestration_stack_resources
+* Used in: OpenStack
+
+| Column                 | Type      | Used in           | Comment |
+| ---------------------- | --------- | ----------------- | ------- |
+| name                   | string    | OpenStack         | The name of the resource |
+| description            | text      | OpenStack         | The description of the resource |
+| logical_resource       | text      | OpenStack         | The same as the name |
+| physical_resource      | text      | OpenStack         | The unique UUID of the resource. <br> For some special types it acts as foreign key, e.g. for OS::Nova::Server, it's the UUID of nova server. |
+| resource_category      | string    | OpenStack         | The type of the resource |
+| resource_status        | string    | OpenStack         | The status of the resource |
+| resource_status_reason | text      | OpenStack         | The reason of the status, usually error message. |
+| last_updated           | datetime  | OpenStack         | |
+| stack_id               | integer   | OpenStack         | ForeignKey |

--- a/architecture/providers_database_architecture/orchestration_template.md
+++ b/architecture/providers_database_architecture/orchestration_template.md
@@ -1,0 +1,14 @@
+# OrchestrationTemplate model documentation
+
+* Table: orchestration_stack_resources
+* Used in: OpenStack
+
+| Column      | Type      | Used in           | Comment |
+| ----------- | --------- | ----------------- | ------- |
+| name        | string    | OpenStack         | The name of the resource |
+| type        | string    | OpenStack         | STI class |
+| description | text      | OpenStack         | The description of the resource |
+| content     | text      | OpenStack         | Template content in YAML format |
+| ems_ref     | string    | OpenStack         |         |
+| created_at  | datetime  | OpenStack         |         |
+| updated_at  | datetime  | OpenStack         |         |

--- a/architecture/providers_database_architecture/security_group.md
+++ b/architecture/providers_database_architecture/security_group.md
@@ -1,0 +1,16 @@
+# SecurityGroup model documentation
+
+* Table: security_groups
+* Used in: Amazon, OpenStack
+* STI models: SecurityGroupAmazon, SecurityGroupOpenStack
+
+| Column                 | Type      | Used in           | Comment |
+| ---------------------- | --------- | ----------------- | ------- |
+| name                   | string    | Amazon, OpenStack | The name of the resource |
+| description            | string    | Amazon, OpenStack | The description of the resource |
+| type                   | string    | Amazon, OpenStack | STI class |
+| ems_id                 | integer   | Amazon, OpenStack |         |
+| ems_ref                | string    | Amazon, OpenStack |         |
+| cloud_network_id       | integer   | OpenStack         | ForeignKey |
+| cloud_tenant_id        | integer   | OpenStack         | ForeignKey |
+| orchestration_stack_id | integer   | OpenStack         | ForeignKey |

--- a/architecture/providers_database_architecture/vm_or_template.md
+++ b/architecture/providers_database_architecture/vm_or_template.md
@@ -1,0 +1,99 @@
+# VmOrTemplate model documentation
+
+TODO better description of model VmOrTemplate
+
+Represents Virtual machines or Templates (Images in OpenStack terminology)
+
+* Table: vms
+* Used in: Kvm, Microsoft, Redhat, Vmware, Xen, OpenStack, Amazon
+* STI models:
+  * Vm
+    * VmInfra
+      * VmKvm
+      * VmMicrosoft
+      * VmRedhat
+      * VmVmware
+      * VmXen
+    * VmCloud
+      * VmAmazon
+      * VmOpenstack
+  * MiqTemplate
+    * TemplateInfra
+      * TemplateKvm
+      * TemplateMicrosoft
+      * TemplateRedhat
+      * TemplateVmware
+      * TemplateXen
+    * TemplateCloud
+      * TemplateAmazon
+      * TemplateOpenstack
+
+| Column                 | Type      | Used in           | Comment |
+| ---------------------- | --------- | ----------------- | ------- |
+| vendor                 | string    | OpenStack         |         |
+| format                 | string    |                   |         |
+| version                | string    |                   |         |
+| name                   | string    | OpenStack         | The name of the VM |
+| description            | text      |                   |         |
+| location               | string    |                   |         |
+| config_xml             | string    |                   |         |
+| autostart              | string    |                   |         |
+| host_id                | integer   |                   | ForeignKey |
+| last_sync_on           | datetime  |                   |         |
+| created_on             | datetime  |                   |         |
+| updated_on             | datetime  |                   |         |
+| storage_id             | integer   |                   | ForeignKey |
+| guid                   | string    |                   |         |
+| ems_id                 | integer   |                   |         |
+| last_scan_on           | datetime  |                   |         |
+| last_scan_attempt_on   | datetime  |                   |         |
+| uid_ems                | string    |                   |         |
+| retires_on             | date      |                   |         |
+| retired                | boolean   |                   |         |
+| boot_time              | datetime  |                   |         |
+| tools_status           | string    |                   |         |
+| standby_action         | string    |                   |         |
+| power_state            | string    |                   |         |
+| state_changed_on       | datetime  |                   |         |
+| previous_state         | string    |                   |         |
+| connection_state       | string    |                   |         |
+| last_perf_capture_on   | datetime  |                   |         |
+| blackbox_exists        | boolean   |                   |         |
+| blackbox_validated     | boolean   |                   |         |
+| registered             | boolean   |                   |         |
+| busy                   | boolean   |                   |         |
+| smart                  | boolean   |                   |         |
+| memory_reserve         | integer   |                   |         |
+| memory_reserve_expand  | boolean   |                   |         |
+| memory_limit           | integer   |                   |         |
+| memory_shares          | integer   |                   |         |
+| memory_shares_level    | string    |                   |         |
+| cpu_reserve            | integer   |                   |         |
+| cpu_reserve_expand     | boolean   |                   |         |
+| cpu_limit              | integer   |                   |         |
+| cpu_shares             | integer   |                   |         |
+| cpu_shares_level       | string    |                   |         |
+| cpu_affinity           | string    |                   |         |
+| ems_created_on         | datetime  |                   |         |
+| template               | boolean   |                   |         |
+| evm_owner_id           | integer   |                   | ForeignKey |
+| ems_ref_obj            | string    |                   |         |
+| miq_group_id           | integer   |                   | ForeignKey |
+| linked_clone           | boolean   |                   |         |
+| fault_tolerance        | boolean   |                   |         |
+| type                   | string    |                   | STI class |
+| ems_ref                | string    |                   |         |
+| ems_cluster_id         | integer   |                   | ForeignKey |
+| retirement_warn        | integer   |                   |         |
+| retirement_last_warn   | datetime  |                   |         |
+| vnc_port               | integer   |                   |         |
+| flavor_id              | integer   | OpenStack, Amazon | ForeignKey |
+| availability_zone_id   | integer   | OpenStack, Amazon | ForeignKey |
+| cloud                  | boolean   |                   |         |
+| retirement_state       | string    |                   |         |
+| cloud_network_id       | integer   | OpenStack         | ForeignKey |
+| cloud_subnet_id        | integer   | OpenStack         | ForeignKey |
+| cloud_tenant_id        | integer   | OpenStack         | ForeignKey |
+| raw_power_state        | string    |                   |         |
+| publicly_available     | boolean   |                   |         |
+| orchestration_stack_id | integer   | OpenStack         | ForeignKey |


### PR DESCRIPTION
Adding doc of providers database architecture. Starting with
skeleton of the tables.
Description is mostly OpenStack driven, we need to fill the
rest of the information regarding the other Providers.
For now, adding only description of models that are used
(or will be) across cloud and infrastructure.
