### PR TITLE
Add OpenStack host model doc

### DIFF
--- a/architecture/providers_database_architecture.md
+++ b/architecture/providers_database_architecture.md
@@ -59,6 +59,7 @@ be filled with EMS_Refresh.
   * HostRedhat
   * HostVmware
     * HostVmwareEsx
+* [Hardware](providers_database_architecture/hardware.md)
 * [AvailabilityZone](providers_database_architecture/availability_zone.md) (STI)
   * AvailabilityZoneAmazon
   * AvailabilityZoneOpenstack

--- a/architecture/providers_database_architecture.md
+++ b/architecture/providers_database_architecture.md
@@ -53,6 +53,7 @@ be filled with EMS_Refresh.
   * [OrchestrationStackResource](providers_database_architecture/orchestration_stack_resource.md)
   * [OrchestrationTemplate](providers_database_architecture/orchestration_template.md)
 * [Host](providers_database_architecture/host.md) (STI)
+  * HostOpenstackInfra
   * HostKvm
   * HostMicrosoft
   * HostRedhat

--- a/architecture/providers_database_architecture/hardware.md
+++ b/architecture/providers_database_architecture/hardware.md
@@ -1,0 +1,36 @@
+# Hardware model documentation
+
+* Table: hosts
+* Used in: Kvm, Microsoft, Redhat, Vmware, OpenstackInfra
+
+| Column                  | Type      | Used in           | Comment |
+| ----------------------- | --------- | ----------------- | ------- |
+| config_version          | string    |                   |         |
+| virtual_hw_version      | string    |                   |         |
+| guest_os                | string    |                   |         |
+| numvcpus                | integer   | OpenstackInfra    | Physical CPU count |
+| bios                    | string    |                   |         |
+| bios_location           | string    |                   |         |
+| time_sync               | string    |                   |         |
+| annotation              | text      |                   |         |
+| vm_or_template_id       | integer   | All               | ForeignKey |
+| memory_cpu              | integer   | OpenstackInfra    | Total memory (Mb) |
+| host_id                 | integer   | All               | ForeignKey        |
+| cpu_speed               | integer   |                   | Processor speed |
+| cpu_type                | string    |                   | Usually string of 'cpu_manufacturer', 'cpu_model' and 'cpu_family' |
+| size_on_disk            | integer   |                   |         |
+| manufacturer            | string    |                   | CPU manufacturer |
+| model                   | string    |                   | CPU model |
+| number_of_nics          | integer   |                   |         |
+| cpu_usage               | integer   |                   |         |
+| memory_usage            | integer   |                   |         |
+| cores_per_socket        | integer   |                   | Cores per CPU |
+| logical_cpus            | integer   |                   | Logical processor count |
+| vmotion_enabled         | boolean   |                   |         |
+| disk_free_space         | integer   |                   |         |
+| disk_capacity           | integer   | OpenstackInfra    | Capacity of the disk (Gb) |
+| guest_os_full_name      | string    |                   |         |
+| memory_console          | integer   |                   |         |
+| bitness                 | integer   |                   |         |
+| virtualization_type     | string    |                   |         |
+| root_device_type        | string    |                   |         |

--- a/architecture/providers_database_architecture/host.md
+++ b/architecture/providers_database_architecture/host.md
@@ -1,8 +1,12 @@
 # Host model documentation
 
+OpenstackInfra host is tied to Ironic service, allowing management and
+inventory collection over Ironic API.
+
 * Table: hosts
-* Used in: Kvm, Microsoft, Redhat, Vmware
+* Used in: Kvm, Microsoft, Redhat, Vmware, OpenstackInfra
 * STI models:
+  * HostOpenstackInfra
   * HostKvm
   * HostMicrosoft
   * HostRedhat
@@ -11,19 +15,19 @@
 
 | Column                  | Type      | Used in           | Comment |
 | ----------------------- | --------- | ----------------- | ------- |
-| name                    | string    |                   |         |
+| name                    | string    | OpenstackInfra    | Name of the host |
 | hostname                | string    |                   |         |
-| ipaddress               | string    |                   |         |
+| ipaddress               | string    | OpenstackInfra    | IP address of the host        |
 | vmm_vendor              | string    |                   |         |
 | vmm_version             | string    |                   |         |
 | vmm_product             | string    |                   |         |
 | vmm_buildnumber         | string    |                   |         |
-| created_on              | datetime  |                   |         |
-| updated_on              | datetime  |                   |         |
+| created_on              | datetime  | All               | Created on timestamp of ManageIQ object |
+| updated_on              | datetime  | All               | Updated on timestamp of ManageIQ object |
 | guid                    | string    |                   |         |
-| ems_id                  | integer   |                   |         |
+| ems_id                  | integer   | All               | ForeignKey |
 | user_assigned_os        | string    |                   |         |
-| power_state             | string    |                   |         |
+| power_state             | string    | OpenstackInfra    | Power state of the host |
 | smart                   | integer   |                   |         |
 | settings                | string    |                   |         |
 | last_perf_capture_on    | datetime  |                   |         |
@@ -34,9 +38,9 @@
 | admin_disabled          | boolean   |                   |         |
 | service_tag             | string    |                   |         |
 | asset_tag               | string    |                   |         |
-| ipmi_address            | string    |                   |         |
-| mac_address             | string    |                   |         |
-| type                    | string    |                   | STI class |
+| ipmi_address            | string    | OpenstackInfra    | IP address of IPMI interface of the host |
+| mac_address             | string    | OpenstackInfra    | Mac address of the host |
+| type                    | string    | All               | STI class |
 | failover                | boolean   |                   |         |
 | ems_ref                 | string    |                   |         |
 | hyperthreading          | boolean   |                   |         |


### PR DESCRIPTION
Adding openstack host model doc, describing what collumns
will be filled by attributes available from OpenStack Ironic
service.