### PR TITLE
Created .haml-lint.yml for miq_bot's upcoming haml-lint feature

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,1 @@
+.rubocop.yml


### PR DESCRIPTION
The miq_bot will also lint haml files and it needs a config file.
For now the haml-lint will use a symlink to .rubocop.yml, but this can change in the future.