### PR TITLE
Store generated data locally on the appliance.

### DIFF
--- a/miq-dev-appliance-setup/MAC/on_appliance/defines.sh
+++ b/miq-dev-appliance-setup/MAC/on_appliance/defines.sh
@@ -1,4 +1,7 @@
 MIQ_DIR=/var/www/miq
 MIQ_SAV_DIR=${MIQ_DIR}.orig
-METADATA_DIR=/var/www/metadata
 DEFAULTS_DIR=/etc/default
+
+LOCAL_METADATA_DIR=/var/www/metadata
+LOCAL_LOG_DIR=/var/www/local_log
+LOCAL_ASSETS_DIR=/var/www/local_assets

--- a/miq-dev-appliance-setup/MAC/on_appliance/map-source.sh
+++ b/miq-dev-appliance-setup/MAC/on_appliance/map-source.sh
@@ -56,10 +56,23 @@ cp $MIQ_DIR/system/LINK/etc/init/evm_watchdog.conf evm_watchdog.conf
 # For fleecing, saving intermediate data to the /var/www/miq/vmdb/data/metadata
 # directory doesn't seem to work reliably through shared folders. To fix this,
 # create a local directory for the metadata and create a symbolic link to it.
-[[ -d $METADATA_DIR ]] || mkdir -p $METADATA_DIR
+[[ -d $LOCAL_METADATA_DIR ]] || mkdir -p $LOCAL_METADATA_DIR
 [[ -d $MIQ_DIR/vmdb/data ]] || mkdir -p $MIQ_DIR/vmdb/data
 [[ -d $MIQ_DIR/vmdb/data/metadata && ! -L $MIQ_DIR/vmdb/data/metadata ]] && rmdir $MIQ_DIR/vmdb/data/metadata
-ln -f -s $METADATA_DIR $MIQ_DIR/vmdb/data/metadata
+ln -f -s $LOCAL_METADATA_DIR $MIQ_DIR/vmdb/data/metadata
+
+# We don't want logs written to our source tree.
+echo "**** Creating link to local log directory..."
+[[ -d $LOCAL_LOG_DIR ]] || mkdir -p $LOCAL_LOG_DIR
+[[ -d $MIQ_DIR/vmdb/log && ! -L $MIQ_DIR/vmdb/log ]] && rmdir $MIQ_DIR/vmdb/log
+ln -f -s $LOCAL_LOG_DIR $MIQ_DIR/vmdb/log
+echo "**** Run: git update-index --assume-unchanged vmdb/log/.gitkeep on MAC."
+
+# We don't want compiled assets written to our source tree.
+# XXX this doesn't work because rake evm:compile_assets removes the link.
+[[ -d $LOCAL_ASSETS_DIR ]] || mkdir -p $LOCAL_ASSETS_DIR
+[[ -d $MIQ_DIR/vmdb/public/assets && ! -L $MIQ_DIR/vmdb/public/assets ]] && rm -rf $MIQ_DIR/vmdb/public/assets
+ln -f -s $LOCAL_ASSETS_DIR $MIQ_DIR/vmdb/public/assets
 
 # Create link to NetApp library Ruby bindings.
 # cd $MIQ_DIR/lib/NetappManageabilityAPI/NmaCore || exit 1

--- a/miq-dev-appliance-setup/MAC/on_appliance/source-updated.sh
+++ b/miq-dev-appliance-setup/MAC/on_appliance/source-updated.sh
@@ -13,6 +13,27 @@ cd $MIQ_DIR/lib/disk/modules || exit 1
 [[ -L MiqBlockDevOps.so ]] && rm -f MiqBlockDevOps.so
 ln -f -s $MIQ_SAV_DIR/lib/disk/modules/MiqBlockDevOps.so MiqBlockDevOps.so
 
+# For fleecing, saving intermediate data to the /var/www/miq/vmdb/data/metadata
+# directory doesn't seem to work reliably through shared folders. To fix this,
+# create a local directory for the metadata and create a symbolic link to it.
+[[ -d $LOCAL_METADATA_DIR ]] || mkdir -p $LOCAL_METADATA_DIR
+[[ -d $MIQ_DIR/vmdb/data ]] || mkdir -p $MIQ_DIR/vmdb/data
+[[ -d $MIQ_DIR/vmdb/data/metadata && ! -L $MIQ_DIR/vmdb/data/metadata ]] && rmdir $MIQ_DIR/vmdb/data/metadata
+ln -f -s $LOCAL_METADATA_DIR $MIQ_DIR/vmdb/data/metadata
+
+# We don't want logs written to our source tree.
+echo "**** Creating link to local log directory..."
+[[ -d $LOCAL_LOG_DIR ]] || mkdir -p $LOCAL_LOG_DIR
+[[ -d $MIQ_DIR/vmdb/log && ! -L $MIQ_DIR/vmdb/log ]] && rmdir $MIQ_DIR/vmdb/log
+ln -f -s $LOCAL_LOG_DIR $MIQ_DIR/vmdb/log
+echo "**** Run: git update-index --assume-unchanged vmdb/log/.gitkeep on MAC."
+
+# We don't want compiled assets written to our source tree.
+# XXX this doesn't work because rake evm:compile_assets removes the link.
+[[ -d $LOCAL_ASSETS_DIR ]] || mkdir -p $LOCAL_ASSETS_DIR
+[[ -d $MIQ_DIR/vmdb/public/assets && ! -L $MIQ_DIR/vmdb/public/assets ]] && rm -rf $MIQ_DIR/vmdb/public/assets
+ln -f -s $LOCAL_ASSETS_DIR $MIQ_DIR/vmdb/public/assets
+
 cd $MIQ_DIR/vmdb || exit 1
 
 # Update gems.


### PR DESCRIPTION
Modified scripts to prevent generated data from being stored on
the MAC via shared folders.