### PR TITLE
Updated bundle command after removed qpid support

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -128,7 +128,7 @@ git fetch other_user
 
 ```bash
 gem install bundler -v "~>1.7.4"
-bundle install --without qpid:metric_fu
+bundle install
 cp config/database.pg.yml config/database.yml
 bundle exec rake evm:db:reset
 bundle exec rake db:seed


### PR DESCRIPTION
Updated `bundle install` command, since we removed Qpid support: https://github.com/ManageIQ/manageiq/pull/4291

@jrafanie 