### PR TITLE
Add some additional hints for OS/X

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -83,18 +83,10 @@ As per 20+, with the following changes:
   brew install git
   brew install memcached
   brew install postgresql
-  brew install graphviz
-  ```
-
-If `bundle install` (when running `bin/setup` below) fails in installing the `eventmachine` gem,
-you may want to run the following and then retry `bundle install`:
-
-  ```bash
-  brew link openssl --force # If installation of eventmachine gem fails
   ```
 
 
-* Configure PostgreSQL
+* Configure and start PostgreSQL
 
   ```bash
   # Enable PostgreSQL on boot
@@ -178,3 +170,22 @@ bin/setup
 * Now you can start the full application with `bundle exec rake evm:start`.
   You can access it at <IP_ADDRESS>:3000. Default username is `admin` and password `smartvm`
 * [Running in minimal mode](developer_setup/minimal_mode.md)
+
+
+#### Some troubleshooting notes
+
+* First login fails
+
+Make sure you have memcached running. If not stop the server with `bundle exec rake evm:stop`,
+start memcached and retry.
+
+* OS/X install is failing on  the `eventmachine` gem
+
+If `bundle install` (when running `bin/setup` below) fails in installing the `eventmachine` gem,
+you may want to run the following and then retry `bundle install`:
+
+  ```bash
+  brew link openssl --force # If installation of eventmachine gem fails
+  ```
+
+

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -83,7 +83,16 @@ As per 20+, with the following changes:
   brew install git
   brew install memcached
   brew install postgresql
+  brew install graphviz
   ```
+
+If `bundle install` (when running `bin/setup` below) fails in installing the `eventmachine` gem,
+you may want to run the following and then retry `bundle install`:
+
+  ```bash
+  brew link openssl --force # If installation of eventmachine gem fails
+  ```
+
 
 * Configure PostgreSQL
 
@@ -91,9 +100,17 @@ As per 20+, with the following changes:
   # Enable PostgreSQL on boot
   mkdir -p ~/Library/LaunchAgents
   ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
-  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
+  launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
 
-  psql -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
+  psql -d postgres -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
+  ```
+
+* Start memcached
+
+  ```bash
+  # Enable Memcached on boot
+  ln -sfv /usr/local/opt/memcached/homebrew.mxcl.memcached.plist ~/Library/LaunchAgents
+  launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.memcached.plist
   ```
 
 ### Install Ruby


### PR DESCRIPTION
Homebrew installs the database as `postgres`. So creating the `root` user needs to run as the postgres database. The Homebrew user is has enough rights to create the role, but psql will not find a `whoami` database to connect to, while the `postgres`one is always there.