### PR TITLE
OSX/Hombrew - Use default db for role creation

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -93,7 +93,7 @@ As per 20+, with the following changes:
   ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
   launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
 
-  psql -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
+  psql -d postgres -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
   ```
 
 ### Install Ruby


### PR DESCRIPTION
I don't recall if this is true for most package managers, but Homebrew
does not create a database for the user's name; Thus, when you run
`psql` or the command here to add the smartvm role, you'll get an error
saying that the database <username> doesn't exist.

Changes the command here to just connect to the internal postgres db to
run this command so it always works exactly as intended.