### PR TITLE
Test suite doc; tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * [Coding Style and Standards](coding_style_and_standards.md)
 * [Developer Setup](developer_setup.md)
   - [Running in minimal mode](developer_setup/minimal_mode.md)
+  - [Running the test suites](developer_setup/running_test_suites.md)
 * [Development Appliance Setup](https://github.com/ManageIQ/manageiq-appliance-dev-setup)
 * [Developer Copr setup for CentOS6](developer_copr_setup_centos6.md)
 * [Running Changelog for Sprints](/community/changelog/)

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -164,13 +164,15 @@ git fetch other_user
 ### Get the Rails environment up and running
 
 ```bash
-bin/setup
+bin/setup                  # Installs dependencies, config, prepares database, etc
+bundle exec rake evm:start # Starts the ManageIQ EVM Application in the background
+bundle exec rails s        # Starts the application server
 ```
 
-* Now you can start the full application with `bundle exec rake evm:start`.
-  You can access it at <IP_ADDRESS>:3000. Default username is `admin` and password `smartvm`
-* [Running in minimal mode](developer_setup/minimal_mode.md)
-
+* You can now access the application at `http://localhost:3000`. The default username is `admin` with password `smartvm`.
+* There is also a minimal mode available to start the application with fewer services and workers for faster startup or
+targeted end-user testing. See the [minimal mode guide](developer_setup/minimal_mode.md) for details.
+* To run the test suites, see [the guide on that topic](developer_setup/running_test_suites.md).
 
 #### Some troubleshooting notes
 

--- a/developer_setup/running_test_suites.md
+++ b/developer_setup/running_test_suites.md
@@ -1,0 +1,57 @@
+## Running the test suites
+
+ManageIQ specs are split into several components:
+
+* **vmdb**
+* **automation**
+* **migrations**
+* **replication**
+* **javascript**
+* **self_service**
+* **brakeman**
+
+Each suite has a pair of Rake tasks to setup and run them, in the form of `test:<type>` and
+`test:<type>:setup` (if required):
+
+```bash
+rake test:vmdb:setup             # Setup environment for vmdb specs
+rake test:vmdb                   # Run all specs except migrations, replication, and automation
+rake test:automation:setup       # Setup environment for automation specs
+rake test:automation             # Run all automation specs
+rake test:migrations:setup       # Setup environment for migration specs
+rake test:migrations             # Run all migration specs
+rake test:replication:setup      # Setup environment for replication specs
+rake test:replication            # Run all replication specs
+rake test:javascript:setup       # Setup environment for javascript specs
+rake test:javascript             # Run all javascript specs
+rake test:self_service           # Run all self_service tests; Requires add'l setup (see below)
+rake test:brakeman               # Run Brakeman
+```
+
+### Self Service UI setup
+
+The Self Service UI tests require additional setup as they use the [Gulp](http://gulpjs.com/) Javascript task runner.
+
+##### Install Node.js
+
+Consult your OS/distribution's package manager to install Node.js. Some common ones:
+
+```bash
+# OSX with Homebrew
+brew install node
+
+# Fedora/RHEL/CentOS
+sudo dnf install nodejs
+```
+
+Alternatively, you can also use binaries/installers available from
+[nodejs.org](https://nodejs.org/en/download/)
+
+##### Install packages and run the tests
+
+```plaintext
+# In ManageIQ directory
+cd spa_ui/self_service
+npm install
+npm test # Or, run the self_service Rake task above
+```


### PR DESCRIPTION
I've tweaked the server startup doc to be a bit more clear and added a doc page on running the test suites.

Suggestions welcome, especially for the Self Service setup as I just made that up quickly without looking too closely at the runner.