### PR TITLE
add ip command

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -83,6 +83,7 @@ As per 20+, with the following changes:
   brew install git
   brew install memcached
   brew install postgresql
+  brew install iproute2mac
   ```
 
 


### PR DESCRIPTION
appliance_console uses `ip` command. `iproute2mac` adds this support
