### PR TITLE
Mention node.js as JS runtime

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -188,4 +188,10 @@ you may want to run the following and then retry `bundle install`:
   brew link openssl --force # If installation of eventmachine gem fails
   ```
 
+* `bin/setup fails` while trying to load the gem 'sprockets/es6' 
+
+If this happens check the log for
+`ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime` a few lines down.
+When this message is present, then the you need to install `node.js` and re-try
+
 


### PR DESCRIPTION
We had a situation today where `bin/setup` failed to load the sprockets gem. It turned out that it could not use the babel gem. Installig nodejs solved the issue.
@himdel found the solution, which got verified by @mattmahoneyrh 