### PR TITLE
Grepping /var/lib/pgsql/data/pg_hba.conf w/o sudo fails with Permission denied

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -38,7 +38,7 @@
   sudo passwd postgres
   # ↑ will ask to choose a password
   sudo postgresql-setup initdb
-  grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee /var/lib/pgsql/data/pg_hba.conf
+  sudo grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee /var/lib/pgsql/data/pg_hba.conf
   sudo sed -i.bak 's/\(^local\s*\w*\s*\w*\s*\)\(peer$\)/\1trust/' /var/lib/pgsql/data/pg_hba.conf
   sudo systemctl enable postgresql
   sudo systemctl start postgresql


### PR DESCRIPTION
Purpose of this command is not to rewrite the `pg_hba.conf` if there is already a record for the local. However, it doesn't work as expected because the grep fails all the time when running without the sudo.

All in all, it kind of works (not as supposed), but it produces this err msg:

```bash
[jkremser@dhcp-10-40-1-43 manageiq master]λ grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee /var/lib/pgsql/data/pg_hba.conf
grep: /var/lib/pgsql/data/pg_hba.conf: Permission denied
```