### PR TITLE
Update rubocop config to be v0.37+ compatible

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,8 +47,6 @@ TrivialAccessors:
 #
 # Enabled/Disabled
 #
-AllCops:
-  RunRailsCops: true
 ClassAndModuleChildren:
   Enabled: false
 DefEndAlignment:
@@ -73,13 +71,15 @@ ParallelAssignment:
   Enabled: false
 PerlBackrefs:
   Enabled: false
+Rails:
+  Enabled: true
 ReadWriteAttribute:
   AutoCorrect: false
 RescueModifier:
   AutoCorrect: false
 SingleLineBlockParams:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 SpecialGlobalVars:
   AutoCorrect: false
@@ -87,7 +87,9 @@ StringLiterals:
   Enabled: false
 StringLiteralsInInterpolation:
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
+  Enabled: false
+TrailingCommaInArguments:
   Enabled: false
 WhileUntilModifier:
   Enabled: false


### PR DESCRIPTION
Some changes were made to the configuration options between 0.34 and
0.37 that made the current .rubocop.yml invalid.

***

Accompanies https://github.com/ManageIQ/manageiq/pull/6866