### PR TITLE
Add cmake to packages to be installed from brew for rugged gem

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -58,6 +58,7 @@
   brew install git
   brew install memcached
   brew install postgresql
+  brew install cmake
   ```
 
 


### PR DESCRIPTION
rugged needs cmake to create the native part and cmake is not installed on os/x by default.