### PR TITLE
Add -a flag to tee command for pg_hba.conf

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -39,7 +39,7 @@
   sudo passwd postgres
   # ↑ will ask to choose a password
   sudo postgresql-setup initdb
-  sudo grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee /var/lib/pgsql/data/pg_hba.conf
+  sudo grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
   sudo sed -i.bak 's/\(^local\s*\w*\s*\w*\s*\)\(peer$\)/\1trust/' /var/lib/pgsql/data/pg_hba.conf
   sudo systemctl enable postgresql
   sudo systemctl start postgresql


### PR DESCRIPTION
Before, this command would have overwritten the entire pg_hba.conf file if you did not have a matching line.
With the -a flag tee will append the line to the end of the file rather than truncating it.

Introduced in #102

@jrafanie @bdunne 