### PR TITLE
Install "npm" in CentOS and Fedora

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -21,7 +21,7 @@
   sudo dnf -y install libxml2-devel libxslt-devel patch  # For Nokogiri Gem
   sudo dnf -y install gcc-c++                            # For event-machine Gem
   sudo dnf -y install sqlite-devel                       # For sqlite3 Gem
-  sudo dnf -y install nodejs                             # For ExecJS Gem used by sprockets/es6 Gem
+  sudo dnf -y install nodejs npm                         # For ExecJS Gem and bower
   sudo dnf -y install openssl-devel                      # For rubygems
   sudo dnf -y install cmake                              # For rugged Gem
   ```


### PR DESCRIPTION
In RPM distributions like CentOS and Fedora the "npm" package is separate, and
not installed by default when Node.js is installed. As a result the execution
of the "bin/setup" will fail if the instructions are followed to setup the
environment from scratch, because it uses the "npm" command to install bower.
This patch changes the instructions so that the "npm" package is also
installed.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>