### PR TITLE
Install bower manually with root

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -26,6 +26,12 @@
   sudo dnf -y install cmake                              # For rugged Gem
   ```
 
+* Install the _Bower_ package manager
+
+  ```
+  sudo npm install -g bower
+  ```
+
 * Enable Memcached
 
   ```bash


### PR DESCRIPTION
Currently the installation of bower is done by the "bin/setup" script,
but this will fail if executed with a non-privileged and the Node.js and
NPM installation was performed by a privileged user. To avoid that
issue, this patch changes the documentation to instruct the user to
install bower manually, with a privileged user.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>