### PR TITLE
Add rubocop rule for curly braces in hash parameter to depend on context

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,8 @@ SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 TrivialAccessors:
   AllowPredicates: true
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
 #
 # Enabled/Disabled
 #


### PR DESCRIPTION
Without this rule, rubocop warns on curly braces in hash parameters, even when all the parameters are hashes, hence removing only from the last one decreases code readability.

Example:
https://github.com/ammendonca/manageiq/blob/c063ed1fea40e8486b90fd26dd879fc9572a3caa/spec/services/middleware_topology_service_spec.rb#L72

More info here:
https://github.com/bbatsov/rubocop/issues/2063