### PR TITLE
PostponedTranslation - use block for the second argument

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -95,7 +95,7 @@ menu_item_text = _(menu_item.text)
 To properly internationalize a string with interpolation that needs to be translated at render time rather than right away, use `PostponedTranslation` class.
 
 ```
-tip = PostponedTranslation.new( _N("%s Alert Profiles"), "already translated string" )
+tip = PostponedTranslation.new( _N("%s Alert Profiles") ) { "already translated string" }
 ```
 
 and then in the place where the value is used you will have:


### PR DESCRIPTION
Updated the `PostponedTranslation` example to match the changes in ManageIQ/manageiq#9086 .. the non-format-string arguments are no longer passed directly to the constructor, instead, a block is passed, which can be evaluated only when the translation is actually needed.

Cc @mzazrivec 