### PR TITLE
Removes rule enforcing no space in curly braces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,8 +40,6 @@ SignalException:
   EnforcedStyle: only_raise
 SingleLineMethods:
   AllowIfMethodIsEmpty: false
-SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
 TrivialAccessors:
   AllowPredicates: true
 Style/BracesAroundHashParameters:


### PR DESCRIPTION
Summary:
![](http://wil.to/_/bikeshed.jpg)

---

Just kidding, I actually have been meaning to submit this since the beginning. This is what I'd consider pretty standard Ruby style across most projects.

See https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#spaces-braces
Also see [how to vote for this change](https://github.com/ManageIQ/guides/pull/137#issuecomment-233012107)

No spaces after (, [ or before ], ). Use spaces around { and before }.

```ruby
# bad
some( arg ).other
[ 1, 2, 3 ].each{|e| puts e}

# good
some(arg).other
[1, 2, 3].each { |e| puts e }
```
{ and } deserve a bit of clarification, since they are used for block and hash literals, as well as string interpolation.

From the bbatsov styleguide:
For hash literals two styles are considered acceptable. **The first variant is slightly more readable (and arguably more popular in the Ruby community in general).** The second variant has the advantage of adding visual difference between block and hash literals. **Whichever one you pick—apply it consistently.**

**Note that I am proposing that you should use the first one consistently**

```ruby
# good - space after { and before }
{ one: 1, two: 2 }

# ok - No bot rule preventing it, but previous example preferred
{one: 1, two: 2}
```

With interpolated expressions, there should be no padded-spacing inside the braces.

```ruby
# bad
"From: #{ user.first_name }, #{ user.last_name }"

# good
"From: #{user.first_name}, #{user.last_name}"
```

r? @Fryguy