### PR TITLE
Fix 'space in hash literals' cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,8 @@ SignalException:
   EnforcedStyle: only_raise
 SingleLineMethods:
   AllowIfMethodIsEmpty: false
+SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
 TrivialAccessors:
   AllowPredicates: true
 Style/BracesAroundHashParameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,8 +40,6 @@ SignalException:
   EnforcedStyle: only_raise
 SingleLineMethods:
   AllowIfMethodIsEmpty: false
-SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
 TrivialAccessors:
   AllowPredicates: true
 Style/BracesAroundHashParameters:
@@ -82,6 +80,8 @@ RescueModifier:
 SingleLineBlockParams:
   Enabled: false
 SpaceBeforeFirstArg:
+  Enabled: false
+SpaceInsideHashLiteralBraces:
   Enabled: false
 SpecialGlobalVars:
   AutoCorrect: false


### PR DESCRIPTION
...by disabling it.


This commit is a replacement for b912041 which accidentally enabled the *opposite* - enforcing a space. This change allows for BOTH styles to be used without the bot screaming at anyone, as was originally intended.