### PR TITLE
Add a note on missing developer tools in OS X

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -204,7 +204,4 @@ When this message is present, then the you need to install `node.js` and re-try
 * `bin/setup` fails while trying to install the 'nokogiri' gem
 
 If this happens, you may be missing developer tools in your OS X. Try to install them with
-```bash
-xcode-select --install
-```
-and then run `bin/setup` again.
+`xcode-select --install` and re-try.

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -201,4 +201,10 @@ If this happens check the log for
 `ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime` a few lines down.
 When this message is present, then the you need to install `node.js` and re-try
 
+* `bin/setup` fails while trying to install the 'nokogiri' gem
 
+If this happens, you may be missing developer tools in your OS X. Try to install them with
+```bash
+xcode-select --install
+```
+and then run `bin/setup` again.


### PR DESCRIPTION
In case ManageIQ is being installed on a fresh OS X chances are that the
developer tools have not been installed. This results in an error about
missing symbols and/or libraries during the installation of Nokogiri gem.

The patch adds a brief explanation in the troubleshooting section
explaining how to install developer tools and try `bin/setup` again.

Signed-off-by: Gregor Berginc <gregor.berginc@xlab.si>