### PR TITLE
Add libcurl for Fedora, used by curb

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -21,6 +21,7 @@
   sudo dnf -y install libxml2-devel libxslt-devel patch  # For Nokogiri Gem
   sudo dnf -y install sqlite-devel                       # For sqlite3 Gem
   sudo dnf -y install nodejs                             # For ExecJS Gem and bower
+  sudo dnf -y install libcurl-devel                      # For Curb
   rpm -q --whatprovides npm || sudo dnf install npm      # For CentOS 7, Fedora 23 and older
   sudo dnf -y install openssl-devel                      # For rubygems
   sudo dnf -y install cmake                              # For rugged Gem


### PR DESCRIPTION
the `Curb` gem wants to install a native extension, which requires `libcurl`.

cc @lucasponce  