### PR TITLE
Loosen rubocop requirements for less noisy PRs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 # Overrides
 #
 AbcSize:
+  Max: 20
   Severity: refactor
 AlignHash:
   EnforcedHashRocketStyle: table


### PR DESCRIPTION
The bot uses this as the base config for running rubocop on our repos.  In PRs I feel like I frequently see comments about AbcSize and line length.  While some people look at this and make corrections, others completely ignore the comments.  Also, [AbcSize](http://www.rubydoc.info/gems/rubocop/0.37.2/RuboCop/Cop/Metrics/AbcSize) is rarely addressed.

ABC Size > 15 is not hard to do.