### PR TITLE
Add a link to the instructions to install PostgreSQL from the PGDG repos

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -41,9 +41,11 @@
   ```
 
 * Configure PostgreSQL
-  * Required PostgreSQL version is 9.4+. See
-  [here](developer_setup/postgresql_software_collection.md) how to install
-  it in Linux distributions like CentOS 7, using _SoftwareCollections.org_.
+  * Required PostgreSQL version is 9.4+.
+    * See [here](developer_setup/postgresql_software_collection.md) how to install
+      it in Linux distributions like CentOS 7, using _SoftwareCollections.org_.
+    * Or follow the directions [here](https://www.postgresql.org/download/linux/redhat/#yum)
+      to install it from the PostgreSQL Global Development Group repositories.
 
   ```bash
   sudo passwd postgres


### PR DESCRIPTION
This can be used on systems which don't offer PostgreSQL 9.4 from their default repos and as an alternative to SCL

Fixes #140