### PR TITLE
Add more docs on angular-gettext caveats

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -109,6 +109,20 @@ won't be collected correctly by `gulp gettext-extract`. The above should correct
 s = sprintf(__("My name is %s."), me.name);
 ```
 
+* Don't apply the `translate` filter on a dynamic content. The string inside would not be correctly extracted during string collection. For example:
+```html
+<span>
+{{ ((magicVariable != null) ? "It's there" : "It's not there") | translate }}
+</span>
+```
+won't be collected correctly by `gulp gettext-extract`. The above should correctly be:
+```html
+<span>
+  <span ng=if="magicVaiable" translate>It's there</span>
+  <span ng=if="!magicVariable" translate>It's not there</span>
+</span>
+```
+
 * Avoid concatenating English strings. For example, a javascript code like:
 ```javascript
 if (action.name == "create") {


### PR DESCRIPTION
This is about not applying `translate` filter on a dynamic content.