### PR TITLE
Remove rest_api file and link to website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ### ManageIQ technical documentation
 * [Architecture](architecture.md)
 * [External Authentication (httpd)](external_auth.md)
-* [REST API](rest_api.md)
+* [REST API](http://manageiq.org/docs/api)
 * [Working with Amazon AWS Config service](providers/amazon_aws_config.md)
 
 ## License

--- a/rest_api.md
+++ b/rest_api.md
@@ -1,8 +1,0 @@
-# REST API
-
-The Appliance REST API guide has moved to the [manageiq_docs](https://github.com/ManageIQ/manageiq_docs) repo.
-
-# License
-
-![Creative Commons License](http://i.creativecommons.org/l/by/3.0/88x31.png)
-This work is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US)


### PR DESCRIPTION
This makes more sense when on the website, and if you’re viewing on Github this is one fewer hops and the docs are readable.