### PR TITLE
No postgres user password is required if sudo is available

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -49,15 +49,13 @@
       to install it from the PostgreSQL Global Development Group repositories.
 
   ```bash
-  sudo passwd postgres
-  # ↑ will ask to choose a password
   sudo postgresql-setup initdb
   sudo grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
   sudo sed -i.bak 's/\(^local\s*\w*\s*\w*\s*\)\(peer$\)/\1trust/' /var/lib/pgsql/data/pg_hba.conf
   sudo systemctl enable postgresql
   sudo systemctl start postgresql
-  su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
-  # ↑ type the password you chose above
+  sudo -u postgres psql -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
+  # This command can return with a "could not change directory to" error, but you can ignore it
   ```
 
 #### Mac


### PR DESCRIPTION
This might return a `could not change directory to` error, but that doesn't interfere with the `psql` command.