### PR TITLE
Update Zanata project links to correct pages

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -268,8 +268,8 @@ The instructions will differ in details depending on the specific ManageIQ proje
 
 We use [Zanata](http://translate.zanata.org) for online translations. We maintain several zanata projects for the ManageIQ project:
 - [ManageIQ](https://translate.zanata.org/project/view/manageiq?dswid=-9684)
-- [ManageIQ Self-Service UI](https://translate.zanata.org/project/view/manageiq-providers-amazon?dswid=1884)
-- [ManageIQ Amazon Provider](https://translate.zanata.org/project/view/manageiq-ui-self_service?dswid=6058)
+- [ManageIQ Service UI](https://translate.zanata.org/project/view/manageiq-ui-service?dswid=8199)
+- [ManageIQ Amazon Provider](https://translate.zanata.org/project/view/manageiq-providers-amazon?dswid=8199)
 
 To be able to use zanata from command line, make sure you have `zanata-cli` installed and configured ([documentation](http://zanata.org/help/)
 


### PR DESCRIPTION
The previous Zanata links for the Service UI and Amazon Provider were
switched. This change corrects the links and changes 'Self-Service' to
'Service' to reflect the repo name change.