### PR TITLE
Improved i18n documentation readability

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -5,7 +5,7 @@
 * [i18n implementation](#i18n-implementation)
 * [Gettext usage](#gettext-usage)
   * [Ruby / HAML](#ruby--haml)
-  * [javascript](#javascript)
+  * [JavaScript](#javascript)
   * [Angular applications](#angular-applications)
   * [Delayed / dynamic translations](#delayed--dynamic-translations)
   * [String interpolation](#string-interpolation)
@@ -38,42 +38,42 @@ ManageIQ supports internationalization of strings in ruby and haml sources as we
 
 The following gettext routines are supported in Ruby and HAML sources:
 
-* `_(msgid)` - translates `msgid` and returns the translated string
+* `_(msgid)` – translates `msgid` and returns the translated string
   * [rubydoc](http://www.rubydoc.info/gems/gettext/GetText#gettext-instance_method)
-* `N_(msgid)` - dynamic translation: this will put `msgid` in the gettext catalog but the string will not be translated by gettext at this time (see delayed translation below)
+* `N_(msgid)` – dynamic translation: this will put `msgid` in the gettext catalog but the string will not be translated by gettext at this time (see delayed translation below)
   * [rubydoc](http://www.rubydoc.info/gems/gettext/GetText#N_-instance_method)
-* `n(msgid, msgid_plural, n)` - returns either translated `msgid` or its translated plural form (`msgid_plural`) depending on `n`, a number determining the count (i.e. number above 1 means plural form)
+* `n(msgid, msgid_plural, n)` – returns either translated `msgid` or its translated plural form (`msgid_plural`) depending on `n`, a number determining the count (i.e. number above 1 means plural form)
   * [rubydoc](http://www.rubydoc.info/gems/gettext/GetText#ngettext-instance_method)
-* `s_(msgid, seperator = "|")` - translates `msgid`, but if there are no localized text, it returns a last part of `msgid` separated by `separator` (`|` by default)
+* `s_(msgid, seperator = "|")` – translates `msgid`, but if there are no localized text, it returns a last part of `msgid` separated by `separator` (`|` by default)
   * [rubydoc](http://www.rubydoc.info/gems/gettext/GetText#sgettext-instance_method)
-* `ns_(msgid, msgid_plural, n, seperator = "|")` - similar to the `n_()`, but if there is no localized text, it returns a last part of `msgid` separated by `separator`.
+* `ns_(msgid, msgid_plural, n, seperator = "|")` – similar to the `n_()`, but if there is no localized text, it returns a last part of `msgid` separated by `separator`.
   * [rubydoc](http://www.rubydoc.info/gems/gettext/GetText#ngettext-instance_method)
 
 ### JavaScript
 
 Internationalization in JavaScript is done with `gettext_i18n_rails_js` gem. The gem extends `gettext_i18n_rails` making the `.po` files available to client side javascript as JSON files.
 
-Unlike ruby / haml sources, javascript uses `__()` (i.e. two underscores rather than one) to invoke gettext. This is done to avoid conflicts with other javascript modules.
+Unlike Ruby / HAML sources, JavaScript uses `__()` *(i.e. two underscores rather than one)* to invoke gettext. This is done to avoid conflicts with other JavaScript modules.
 
-The gettext routines supported in javascript sources:
+The gettext routines supported in JavaScript sources:
 
 * `__(msgid)`
 * `n_(msgid, msgid_plural, n)`
 * `s_(msgid)`
 
-The semantic is similar to the ruby equivalents.
+The semantic is similar to the Ruby equivalents.
 
 ### Angular applications
 
 Purely Angular applications, such as Self-Service UI, use [angular-gettext](https://angular-gettext.rocketeer.be/) for internationalization.
-The `angular-gettext` module allows for annotating parts of the angular application (html of javascript), which need to be translated.
+The `angular-gettext` module allows for annotating parts of the Angular application (HTML of JavaScript), which need to be translated.
 
 Guides for annotating content:
 
-* [html files](https://angular-gettext.rocketeer.be/dev-guide/annotate/)
-* [javascript files](https://angular-gettext.rocketeer.be/dev-guide/annotate-js/)
+* [HTML files](https://angular-gettext.rocketeer.be/dev-guide/annotate/)
+* [JavaScript files](https://angular-gettext.rocketeer.be/dev-guide/annotate-js/)
 
-Note, that in Self-Service UI, thanks to
+Note, that in Self-Service UI, thanks to:
 
 * [N_ alias](https://github.com/ManageIQ/manageiq/blob/master/spa_ui/self_service/client/app/config/gettext.config.js#L20)
 * [__ alias](https://github.com/ManageIQ/manageiq/blob/master/spa_ui/self_service/client/app/config/gettext.config.js#L21)
@@ -83,7 +83,7 @@ we can use `N_()` and `__()` in javascript sources instead of regular `angular-g
 #### Substitute filter
 
 In certain situations, it's not possible to correctly annotate strings for translation when these
-strings are a value of an html element and contain a variable interpolation. For example:
+strings are a value of an HTML element and contain a variable interpolation. For example:
 
 ```html
 <span tooltip="{{item.v_total_vms}} VMs">
@@ -94,6 +94,7 @@ This is where the `substitute` filter comes in handy. The above situation would 
 ```html
 <span tooltip="{{ '[[number]] VMs'|translate|substitute:{number: item.v_total_vms} }}">
 ```
+
 i.e. `[[` and `]]` mark start and end of a variable to be substituted, the actual values would be
 then substituted with the context of the `substitute` filter.
 
@@ -101,7 +102,7 @@ then substituted with the context of the `substitute` filter.
 
 There are certain aspects of using `angular-gettext` you should be aware of.
 
-* Be careful where you put the `translate` directive. For example, a markup like:
+* **Be careful where you put the `translate` directive**. For example, a markup like:
 
 ```html
 <div class="outside" translate>
@@ -121,22 +122,28 @@ will result in the whole
 
 block being collected during string extraction by `gulp gettext-extract`. Correctly, the `translate` directive should be placed inside the `span` element.
 
-* Don't use dynamic content inside `__()`. For example, the following javascript code:
+* **Don't use dynamic content inside `__()`**. For example, the following javascript code won't be collected correctly by `gulp gettext-extract`.
+
 ```javascript
 s = __(sprintf("My name is %s.", me.name));
 ```
-won't be collected correctly by `gulp gettext-extract`. The above should correctly be:
+
+The above should correctly be:
+
 ```javascript
 s = sprintf(__("My name is %s."), me.name);
 ```
 
-* Don't apply the `translate` filter on a dynamic content. The string inside would not be correctly extracted during string collection. For example:
+* **Don't apply the `translate` filter on a dynamic content**. The string inside would not be correctly extracted during string collection. For example the following won't be collected correctly by `gulp gettext-extract`.
+
 ```html
 <span>
 {{ ((magicVariable != null) ? "It's there" : "It's not there") | translate }}
 </span>
 ```
-won't be collected correctly by `gulp gettext-extract`. The above should correctly be:
+
+The above should correctly be:
+
 ```html
 <span>
   <span ng=if="magicVaiable" translate>It's there</span>
@@ -144,7 +151,8 @@ won't be collected correctly by `gulp gettext-extract`. The above should correct
 </span>
 ```
 
-* Avoid concatenating English strings. For example, a javascript code like:
+* **Avoid concatenating English strings.** For example, a javascript code like:
+
 ```javascript
 if (action.name == "create") {
   var verb = "created";
@@ -153,7 +161,11 @@ if (action.name == "create") {
 }
 message = sprintf(__("Item was %s"), verb);
 ```
-would contain mixed languages when shown in non-English locale. Correctly, the code should read:
+
+would contain mixed languages when shown in non-English locale.
+
+Correctly, the code should read:
+
 ```javascript
 if (action.name == "create") {
   message = __("Item was created");
@@ -170,26 +182,26 @@ Sometimes we need to delay translation of a string to a later time. For example 
 
 In the simplest case you can use `N_('bar')` saying "do not translate this string" such as:
 
-```
+```ruby
 menu_item = Menu::Item.new(N_('Cloud Tennants')
 ```
 
 and such strings will be caught by the `rake gettext:find` task so these strings end up in the catalog.
-Then you do the translation when needed (e.g. when generating the HTML or JSON format of the data) by calling `_()` such as:
+Then you do the translation when needed *(e.g. when generating the HTML or JSON format of the data)* by calling `_()` such as:
 
-```
+```ruby
 menu_item_text = _(menu_item.text)
 ```
 
 To properly internationalize a string with interpolation that needs to be translated at render time rather than right away, use `PostponedTranslation` class.
 
-```
+```ruby
 tip = PostponedTranslation.new( _N("%s Alert Profiles") ) { "already translated string" }
 ```
 
 and then in the place where the value is used you will have:
 
-```
+```ruby
 translated_tip = tip.kind_of?(Proc) ? tip.call : _(tip)
 ```
 
@@ -197,68 +209,67 @@ translated_tip = tip.kind_of?(Proc) ? tip.call : _(tip)
 
 Whenever you need to use string interpolation inside a gettext call, you need to follow several rules.
 
-* different languages might have different word orders so we use named placeholders:
+* different languages might have different word orders so we **use named placeholders**:
 
-```
+```ruby
 _("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model=>"MiqReport"), :name => @rpt.name}
 ```
 
-These forms are not acceptable:
+These forms **are not acceptable**:
 
-```
+```ruby
 _("%s (All %s)" % [@ems_cluster.name, title_for_hosts]) # the name of the placeholder can provide vital information to the translator
 _("No %s were selected to move up") % "fields"          # use named placeholder even in the case of a single placeholder
 ```
 
-* do not use variables inside gettext strings as these will not be extracted and placed in the gettext catalog
+* **do not use variables inside gettext strings** as these will not be extracted and placed in the gettext catalog
 
-Incorrect:
+**Incorrect**:
 
-```
+```ruby
 text = "Some random text"
 _(text)
 ```
 
-Correct:
+**Correct**:
 
-```
+```ruby
 _("Some random text")
 ```
 
 ### Marking gettext strings in UI
 
-To be able to see strings which pass through gettext (i.e. are translatable), you have to add the following to the servers advanced settings:
+To be able to see strings which pass through gettext *(i.e. are translatable)*, you have to add the following to the servers advanced settings:
 
-```
+```yaml
 ui:
   mark_translated_strings: true
 ```
-and restart the ManageIQ application. With these settings on, all strings passing through gettext will be marked with `»` and `«` markers:
+
+and **restart** the ManageIQ application. With these settings on, all strings passing through gettext will be marked with `»` and `«` markers:
 
 ```
 »webui text that went through some of the gettext routines«
 ```
 
-
 ## Translating ManageIQ
 
-To contribute with translation to ManageIQ, create an account at [zanata](translate.zanata.org)
+To contribute with translation to ManageIQ, create an account at [Zanata](translate.zanata.org)
 and navigate to [ManageIQ project page](https://translate.zanata.org/zanata/project/view/manageiq)
 
 ### Translator notes
 
-* How do I translate keys in the form of `Hardware|Usage`? What do they mean?
-`Hardware|Usage` means Usage in namespace Hardware. This is the way we translate model attributes for ActiveRecord models for example. You do not have to translate "Hardware", just translate "Usage".
+* **How do I translate keys in the form of `Hardware|Usage`? What do they mean?**
+  * `Hardware|Usage` means Usage in namespace Hardware. This is the way we translate model attributes for ActiveRecord models for example. You do not have to translate "Hardware", just translate "Usage".
 
-* what does the key `locale_name` mean?
-`local_name` meens name of the given language in the language itself. Such as "Deutsch" for German or "Česky" for Czech. Make sure to provide the value for this key, without it the language/locale cannot be presented in the UI.
-
+* **What does the key `locale_name` mean?**
+  * `local_name` meens name of the given language in the language itself. Such as "Deutsch" for German or "Česky" for Czech. Make sure to provide the value for this key, without it the language/locale cannot be presented in the UI.
 
 ## Updating translations (developers)
 
 The general workflow for updating translations is:
 * extract strings from source code and create new gettext catalog.
-* upload the new catalog into a translation tool (we use Zanata).
+* upload the new catalog into a translation tool *(we use Zanata)*.
 * once the translations for the languages are complete, fetch the translations from the translation tool and put them into git.
 
 The instructions will differ in details depending on the specific ManageIQ project.
@@ -283,7 +294,7 @@ Steps for updating translations:
 * Update gettext catalogs in ManageIQ git repository. This is done to make sure the gettext catalog contains up to date (i.e. current) strings for translators.
 To update the catalog, run the following rake task in the root of ManageIQ git checkout:
 
-```
+```sh
 $ bundle exec rake locale:update
 ```
 
@@ -305,7 +316,7 @@ config/locales/*/*.po
 
 * Upload the catalog created in previous step to [zanata](http://translate.zanata.org):
 
-```
+```sh
 $ cd config/locales
 $ zanata-cli push --push-type source
 ```
@@ -316,7 +327,7 @@ Now translators in zanata will have the latest stuff to translate available.
 
 Run the following in ManageIQ git checkout:
 
-```
+```sh
 $ cd config/locales
 $ zanata-cli pull --pull-type trans    # add --locales ... if you wish to download only specific locales
 $ bundle exec rake gettext:po_to_json
@@ -325,7 +336,7 @@ $ bundle exec rake gettext:po_to_json
 If you are adding new locales / languages to ManageIQ, don't forget to create yaml file containing localized names of each included
 language. From the root of ManageIQ checkout, run the following:
 
-```
+```sh
 $ bundle exec rake locale:extract_locale_names
 ```
 
@@ -344,38 +355,38 @@ config/human_locale_names.yaml        # optionally, if you added locales
 
 * Update the gettext catalogs:
 
-```
+```sh
 $ cd client
 $ gulp gettext-extract
 ```
 
 * Upload the catalogs to zanata:
 
-```
+```sh
 $ zanata-cli push --push-type source
 ```
 
 * Once the translations are complete, download the translated catalogs:
 
-```
+```sh
 $ zanata-cli pull --pull-type trans --locales ...
 ```
 
 * Convert the translated .po catalogs into .json files:
 
-```
+```sh
 $ gulp gettext-compile
 ```
 
 * Update locale names:
 
-```
+```sh
 $ gulp available-languages
 ```
 
 * Commit and push the new content into git:
 
-```
+```sh
 $ git commit client/gettext/po client/gettext/json
 $ git push
 ```
@@ -386,25 +397,25 @@ This procedure would apply to all rails engines hooked into ManageIQ in general.
 
 * Update the gettext catalog. With the Amazon provider engine (plugin) hooked into your ManageIQ instance, run the following from the ManageIQ git checkout:
 
-```
+```sh
 $ rake locale:plugin:find[ManageIQ::Providers::Amazon]
 ```
 
 * Upload the catalog to zanata:
 
-```
+```sh
 $ zanata-cli push --push-type source
 ```
 
 * Once the translations are complete, download the translated catalogs:
 
-```
+```sh
 $ zanata-cli pull --pull-type trans --locales ...
 ```
 
 * Commit and push the new catalogs into git:
 
-```
+```sh
 $ git commit locale/
 $ git push
 ```
@@ -414,7 +425,7 @@ $ git push
 
 * Create an initializer in your engine / plugin with a content similar to:
 
-```
+```sh
 $ cat config/initializers/gettext.rb
 Vmdb::Gettext::Domains.add_domain('ManageIQ_Providers_Amazon',
   ManageIQ::Providers::Amazon::Engine.root.join('locale').to_s,
@@ -424,7 +435,7 @@ Vmdb::Gettext::Domains.add_domain('ManageIQ_Providers_Amazon',
 
 * Initial extraction of gettext strings found in your engine / plugin:
 
-```
+```sh
 $ cd /path/to/your/plugin/root
 $ mkdir ./locale
 $ for locale in en, ...; do mkdir ./locale/$locale; done


### PR DESCRIPTION
Markdown on GitHub seems to parse differently than parser that is used for ManageIQ.org page, see http://manageiq.org/docs/guides/i18n

There has to be spaces around code blocks

@mzazrivec please review