### PR TITLE
UI split instructions - fix step 6 - wrong symlink

### DIFF
--- a/developer_setup/classic_ui_split.md
+++ b/developer_setup/classic_ui_split.md
@@ -14,7 +14,7 @@ But if you do..
 1. `git clone git@github.com:YOU/manageiq-ui-classic`
 1. `cd manageiq-ui-classic`
 1. `git remote add upstream git@github.com:ManageIQ/manageiq-ui-classic.git`
-1. `ln -s ../manageiq spec/`
+1. `ln -s ../../manageiq spec/`
 1. `cd ../manageiq`
 1. `echo 'gem "manageiq-ui-classic", :path => "../manageiq-ui-classic/"' >> Gemfile.dev.rb`
 1. `bin/update`


### PR DESCRIPTION
Previous version would create the `spec/manageiq` symlink pointing to `manageiq-ui-classic/manageiq`. Adding more `../` :)