### PR TITLE
UI split - use absolute path for the manageiq-ui-classic :git link

### DIFF
--- a/developer_setup/classic_ui_split.md
+++ b/developer_setup/classic_ui_split.md
@@ -16,7 +16,7 @@ But if you do..
 1. `git remote add upstream git@github.com:ManageIQ/manageiq-ui-classic.git`
 1. `ln -s ../../manageiq spec/`
 1. `cd ../manageiq`
-1. `echo 'gem "manageiq-ui-classic", :path => "../manageiq-ui-classic/"' >> Gemfile.dev.rb`
+1. `echo 'gem "manageiq-ui-classic", :path => "'$(cd ../manageiq-ui-classic/; /bin/pwd)'"' >> Gemfile.dev.rb` (because you really need an absolute path there..)
 1. `bin/update`
 
 And you should be set :).


### PR DESCRIPTION
because otherwise, we get an error trying to find `spec/manageiq-ui-classic`

Cc @Fryguy 