### PR TITLE
UI split - add a guard around the gem in Gemfile.dev.rb

### DIFF
--- a/developer_setup/classic_ui_split.md
+++ b/developer_setup/classic_ui_split.md
@@ -16,10 +16,17 @@ But if you do..
 1. `git remote add upstream git@github.com:ManageIQ/manageiq-ui-classic.git`
 1. `ln -s ../../manageiq spec/`
 1. `cd ../manageiq`
-1. `echo 'gem "manageiq-ui-classic", :path => "'$(cd ../manageiq-ui-classic/; /bin/pwd)'"' >> Gemfile.dev.rb` (because you really need an absolute path there..)
+1. `echo 'unless dependencies.detect { |d| d.name == "manageiq-ui-classic" }' >> Gemfile.dev.rb`
+1. `echo '  gem "manageiq-ui-classic", :path => "'$(cd ../manageiq-ui-classic/; /bin/pwd)'"' >> Gemfile.dev.rb` (because you really need an absolute path there..)
+1. `echo 'end' >> Gemfile.dev.rb`
 1. `bin/update`
 
 And you should be set :).
+
+
+---
+
+If you used a version of this guide from before Jan 2, you'll need to manually update your `Gemfile.dev.rb` to include that `unless`.
 
 
 ### Migrating a PR from the old repo


### PR DESCRIPTION
needed to be able to run `bundle install` in ui-classic, when the `Gemfile` contains `gemspec`.

Fixes ManageIQ/manageiq-ui-classic#42