### PR TITLE
Empty methods don't have to be onelined.

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -47,6 +47,8 @@ Style/CollectionMethods:
     reduce: inject
 Style/Documentation:
   Enabled: false
+Style/EmptyMethod:
+  Enabled: false
 Style/Encoding:
   Enabled: false
 Style/ExtraSpacing:


### PR DESCRIPTION
There are times that onelining a method is fine.  There are times
when it's not.  Let the developer decide when it's appropriate.

cc @bdunne @Fryguy @chrisarcand 

This PR will hopefully cut down on some of the noise seen in many files:

![image](https://cloud.githubusercontent.com/assets/19339/21733836/80912592-d42e-11e6-8ac7-fed497615a9b.png)
