### PR TITLE
change docs to plugin development

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -157,19 +157,45 @@ git remote add other_user git@github.com:OtherUser/manageiq.git
 git fetch other_user
 ```
 
-### Clone the pluggable providers
+### Clone some plugins
 
-If you want to do a providers development, clone them locally.
+If you want to do ManageIQ plugin development, you clone plugins locally. E.g.
 
 ```bash
-git clone git@github.com:JoeSmith/manageiq-providers-amazon.git providers/manageiq-providers-amazon
+cd manageiq ; mkdir plugins
+git clone git@github.com:JoeSmith/manageiq-providers-amazon.git plugins/manageiq-providers-amazon
+git clone git@github.com:JoeSmith/manageiq-content.git plugins/manageiq-content
+git clone git@github.com:JoeSmith/manageiq-ui-classic.git plugins/manageiq-ui-classic
 ```
 
-In your local Gemfile.dev.rb add:
+In your local Gemfile.dev.rb in your ManageIQ checkout add:
 
 ```bash
-dependencies.reject!{|d| d.name == 'manageiq-providers-amazon'}
-gem "manageiq-providers-amazon", :path => File.expand_path("providers/manageiq-providers-amazon", __dir__)
+override_gem 'manageiq-providers-amazon', :path => File.expand_path('plugins/manageiq-providers-amazon', __dir__)
+override_gem 'manageiq-content', :path => File.expand_path('plugins/manageiq-providers-amazon', __dir__)
+override_gem 'manageiq-ui-classic', :path => File.expand_path('plugins/manageiq-ui-classic', __dir__)
+```
+
+In your plugin, just use `bin/setup` and `bin/update` as usual. This will checkout a shallow copy of ManageIQ as a
+dummy app to run the test.
+
+```bash
+cd plugins/manageiq-providers-amazon
+bin/setup
+# == Cloning manageiq sample app ==
+# Cloning into 'spec/manageiq'...
+bin/update
+# == Updating manageiq sample app ==
+```
+
+Alternatively you can symlink `spec/manageiq` to your local ManageIQ clone, which will allow you to run tests against
+a local manageiq feature branch.
+
+```bash
+cd plugins/manageiq-providers-amazon
+ln -s ~/src/manageiq spec/manageiq
+bin/update
+# == SKIPPING update of spec/manageiq because its symlinked ==
 ```
 
 ### Get the Rails environment up and running

--- a/developer_setup/classic_ui_split.md
+++ b/developer_setup/classic_ui_split.md
@@ -16,18 +16,10 @@ But if you do..
 1. `git remote add upstream git@github.com:ManageIQ/manageiq-ui-classic.git`
 1. `ln -s ../../manageiq spec/`
 1. `cd ../manageiq`
-1. `echo 'unless dependencies.detect { |d| d.name == "manageiq-ui-classic" }' >> Gemfile.dev.rb`
-1. `echo '  gem "manageiq-ui-classic", :path => "'$(cd ../manageiq-ui-classic/; /bin/pwd)'"' >> Gemfile.dev.rb` (because you really need an absolute path there..)
-1. `echo 'end' >> Gemfile.dev.rb`
+1. `echo "override_gem 'manageiq-ui-classic', :path => File.expand_path('../manageiq-ui-classic', __dir__) >> Gemfile.dev.rb`
 1. `bin/update`
 
 And you should be set :).
-
-
----
-
-If you used a version of this guide from before Jan 2, you'll need to manually update your `Gemfile.dev.rb` to include that `unless`.
-
 
 ### Migrating a PR from the old repo
 


### PR DESCRIPTION
* change notion to plugin development rather than provider development
* make use of `override_gem` method

I also added tweaked it to clone the plugins in a subdirectory ***inside*** your manageiq checkout.
I know it's controversial and debatable. But I think it reduces the chance of breaking other plugins or the core, because doing `ag -r` or `grep -r` or whatever to grep through your directory will also hit the plugins. (Some commands, like `git grep` will not, but alas)

I tend to make that change also to the `developer_setup/classic_ui_split.md` file.

wdyt @martinpovolny @himdel @Fryguy @bdunne 

https://github.com/ManageIQ/manageiq/pull/13193 would add `plugins/` to `.gitignore`