### PR TITLE
Clarify Ruby style guide reference

### DIFF
--- a/coding_style_and_standards.md
+++ b/coding_style_and_standards.md
@@ -28,8 +28,10 @@ maintained by the ManageIQ team.
 
 ## Ruby Style Guide
 
-* Refer to [our fork](http://github.com/ManageIQ/ruby-style-guide) of the
-  [original Ruby style guide](https://github.com/bbatsov/ruby-style-guide).
+* We follow, with some exceptions, the [original Ruby style guide](https://github.com/bbatsov/ruby-style-guide).
+  Any changes we have that deviate from the default style guide are enumerated
+  in the [.rubocop_base.yml](.rubocop_base.yml) file, which is inherited by most
+  projects in the ManageIQ organization.
 
 ## Logging
 


### PR DESCRIPTION
The old text referenced a very old fork of the Ruby style guide, however
it is very difficult to keep that up to date.  Instead, I think it's
easier to reference the current Ruby style guide, and then point out the
limited number of changes we enforce through rubocop.

@jrafanie Please review.

This will also allow me to delete the current fork of the ruby style guide we
have, as I feel it's counterproductive.