### PR TITLE
Document openscap lib required for openscap gem to work

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -26,6 +26,7 @@
   rpm -q --whatprovides npm || sudo dnf -y install npm   # For CentOS 7, Fedora 23 and older
   sudo dnf -y install openssl-devel                      # For rubygems
   sudo dnf -y install cmake                              # For rugged Gem
+  sudo dnf -y install openscap                           # For openscap Gem
   ```
 
 * Install the _Bower_ package manager


### PR DESCRIPTION
Unusually, since the gem uses FFI at runtime, you don't need this lib
for `bundle install` to succeed, but `require 'openscap'` will fail.

Moreover, app/models/openscap_result.rb currently swallows the `require` failure,
resulting in more confusing ``undefined method `oscap_cleanup'`` error:
https://gist.github.com/cben/11af8299c6c85111f5355b6db8c750ce

@moolitayer please review.
- Is `openscap` package enough without `openscap-devel`?  Seems to work.
- This is too easy to miss, I was never aware I need it.
  Could we maybe arrange for bundler or bin/setup to fail / give warning
  without it?
- I think `with_openscap_arf` should validate `openscap_available?`
  returned true, but that's a separate discussion.