### PR TITLE
Disable enforcement of %r{} in regex

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -70,6 +70,8 @@ Style/ParallelAssignment:
   Enabled: false
 Style/RedundantReturn:
   AllowMultipleReturnValues: true
+Style/RegexpLiteral:
+  Enabled: false
 Style/RescueModifier:
   AutoCorrect: false
 Style/SignalException:


### PR DESCRIPTION
Using `//` to delimit regular expressions is something found in most languages and feels much more natural to me than `%r{}`. I believe that people must at least partially agree with me, as I've put slashes in regexs in my code constantly without complaint. Given that this has happened over and over, I don't see a point in continuing to ignore a cop when we can just disable it.

I believe the argument against using slashes is that you then must escape forward slashes in your regex. I think this is a pretty weak point, as you still need to escape other such special characters anyway.

I have turned enforcement of style for regexs off rather than enforcing slashes. Note we can also enforce slashes on single line regexs and %r for multiline if you like. I'm against mixed because although I think you should use %r for multiline, I'm of the opinion that if you have a regex that requires multiple lines you are very likely Doing It Wrong™

```
# Use `/` or `%r` around regular expressions.
Style/RegexpLiteral:
  EnforcedStyle: slashes
  # slashes: Always use slashes.
  # percent_r: Always use `%r`.
  # mixed: Use slashes on single-line regexes, and `%r` on multi-line regexes.
  SupportedStyles:
    - slashes
    - percent_r
    - mixed
  # If `false`, the cop will always recommend using `%r` if one or more slashes
  # are found in the regexp string.
  AllowInnerSlashes: false
```