### PR TITLE
Updated Target Ruby Version to Ruby 2.3

### DIFF
--- a/.rubocop_cc_base.yml
+++ b/.rubocop_cc_base.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Lint/AmbiguousOperator:
   Enabled: true


### PR DESCRIPTION
We are running 2.3 on appliances and this now allowes Rubocop to
understand features in Ruby 2.3 such as the lonely operator &.