### PR TITLE
clarify openscap is only needed for some container SSA functionality

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -26,7 +26,7 @@
   rpm -q --whatprovides npm || sudo dnf -y install npm   # For CentOS 7, Fedora 23 and older
   sudo dnf -y install openssl-devel                      # For rubygems
   sudo dnf -y install cmake                              # For rugged Gem
-  sudo dnf -y install openscap                           # For openscap Gem
+  sudo dnf -y install openscap                           # Optional, for openscap Gem for container SSA
   ```
 
 * Install the _Bower_ package manager


### PR DESCRIPTION
Followup to #189

Without the lib, manageiq will not crash, but some of the container SSA
functionality will be skipped.
AFAICT it affects:
- collection of `OpenscapResult` (`collect_compliance_data`)
- its parsing into `OpenscapRuleResult`s (`create_rule_results`).
- display of these results.