### PR TITLE
UI split - make the ln -s not rely on current path vs target path

### DIFF
--- a/developer_setup/classic_ui_split.md
+++ b/developer_setup/classic_ui_split.md
@@ -14,7 +14,7 @@ But if you do..
 1. `git clone git@github.com:YOU/manageiq-ui-classic`
 1. `cd manageiq-ui-classic`
 1. `git remote add upstream git@github.com:ManageIQ/manageiq-ui-classic.git`
-1. `ln -s ../manageiq spec/`
+1. `cd spec/ ; ln -s ../../manageiq . ; cd ..` (and ensure the link is valid)
 1. `cd ../manageiq`
 1. `echo "override_gem 'manageiq-ui-classic', :path => File.expand_path('../manageiq-ui-classic', __dir__)" >> Gemfile.dev.rb`
 1. `bin/update`


### PR DESCRIPTION
seems like some `ln` implementations resolve relative paths on link creation, while others just create the link, doing the resolve only when accessed.

That makes `ln -s ../../manageiq/ spec/` ambiguous.

Resolving by explicitly cding to `spec` first.

---

Cc @Fryguy , @chessbyte , @isimluk (because you all were active in #188)