### PR TITLE
Adds minishift instructions to the openshift developer guides

### DIFF
--- a/providers/openshift.md
+++ b/providers/openshift.md
@@ -1,21 +1,30 @@
 ## ManageIQ Openshift Container Provider
 
 ### Deploying OpenShift With Ansible
+
 Get openshift-ansible:
 
-```git clone https://github.com/openshift/openshift-ansible.git```
+```console
+$ git clone https://github.com/openshift/openshift-ansible.git
+```
 
 Generate an ssh key if needed:
 
-``ssh-keygen```
+```console
+$ ssh-keygen
+```
 
 Configure ssh key authentication to all the machines:
 
-```ssh-copy-id root@hostname```
+```console
+$ ssh-copy-id root@hostname
+```
 
-The inventory file describes all the nodes and masters in the cluster. A simple example file for a cluster composed of two machines (Master and Node):
+The inventory file describes all the nodes and masters in the cluster. A simple
+example file for a cluster composed of two machines (Master and Node):
 
-```[OSEv3:children]
+```INI
+[OSEv3:children]
 masters
 nodes
  
@@ -32,9 +41,11 @@ master_hostname
 node_hostname
 ```
 
-openshift_use_manageiq is set to True to configure the Service Account needed by ManageIQ. there are more like variables like use_metrics to enable other options in OpenShift.
-A more detailed example will be found in inventory/byo/hosts.example.
+openshift_use_manageiq is set to True to configure the Service Account needed
+by ManageIQ. there are more like variables like use_metrics to enable other
+options in OpenShift.  A more detailed example will be found in
+inventory/byo/hosts.example.
 
-openshift_use_manageiq is set to True to configure the Service Account needed by ManageIQ. there are more like variables like use_metrics to enable other options in OpenShift.
-A more detailed example will be found in inventory/byo/hosts.example.
-```ansible-playbook playbooks/byo/config.yml -i path/to/inventory/file```
+```console
+$ ansible-playbook playbooks/byo/config.yml -i path/to/inventory/file
+```

--- a/providers/openshift.md
+++ b/providers/openshift.md
@@ -1,5 +1,16 @@
 ## ManageIQ Openshift Container Provider
 
+Two deployment options are suggested here to deploy an openshift origin
+provider for ManageIQ:
+
+- using [openshift-ansible](https://github.com/openshift/openshift-ansible) to
+  deploy RPM packages on a cluster
+- using [minishift]((https://github.com/minishift/minishift)) to deploy
+  openshift source to a vm
+
+You can also use `oc cluster up` and configure it yourself (instructions not
+provided) as another alternative.
+
 ### Deploying OpenShift With Ansible
 
 Get openshift-ansible:

--- a/providers/openshift.md
+++ b/providers/openshift.md
@@ -42,7 +42,6 @@ nodes
 [OSEv3:vars]
 ansible_ssh_user=root
 deployment_type=origin
-openshift_use_manageiq=True
  
 [masters]
 master_hostname openshift_scheduleable=True
@@ -52,10 +51,11 @@ master_hostname
 node_hostname
 ```
 
-openshift_use_manageiq is set to True to configure the Service Account needed
-by ManageIQ. there are more like variables like use_metrics to enable other
-options in OpenShift.  A more detailed example will be found in
-inventory/byo/hosts.example.
+There are more like variables like `use_metrics` to enable other options in
+OpenShift.  A more detailed example can be found in
+`inventory/byo/hosts.origin.example`. Specifically, to deploy metrics and
+logging use `openshift_hosted_metrics_deploy=True` and
+`openshift_hosted_logging_deploy=True`
 
 ```console
 $ ansible-playbook playbooks/byo/config.yml -i path/to/inventory/file


### PR DESCRIPTION
Also fixes some typos and cleans up the original docs for openshift.


~~Note:  There is currently a [bug with minishift](https://github.com/minishift/minishift/issues/710) when using the described addon.  Eventually, the idea is that this guide can be trimmed down if this addon is included in the core `minishift` project, but for now, a workaround has been included to make this work regardless if that bug is fixed or not.~~

This bug has been isolated [here](https://github.com/minishift/minishift/issues/729), and the current workaround is to just not used string based args with spaces (which I have updated the addon to do).