### PR TITLE
developer_setup - debian - add libssl1.0-dev needed for puma

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -75,6 +75,7 @@
   sudo apt install libcurl4-gnutls-dev              # For Curb
   sudo apt install cmake                            # For rugged Gem
   sudo apt install libgit2-dev pkg-config libtool
+  sudo apt install libssl1.0-dev                    # for puma < 3.7.0
   ```
 
 * Install the _Bower_ and _Yarn_ package manager


### PR DESCRIPTION
for puma < 3.7.0, we need `libssl1.0-dev`
(presumably, for the newer one, it will be `libssl-dev`)

Relevant issue:
https://github.com/puma/puma/issues/1136

Fixed by:
https://github.com/puma/puma/pull/1178