### PR TITLE
Fix link to "Smart State Analysis demo"

### DIFF
--- a/providers/containers.md
+++ b/providers/containers.md
@@ -8,7 +8,7 @@ Current architecture diagram:
 
 ![container smart state analysis diagram](/images/containers-ssa.png "container smart state analysis")
 
-[Smart State Analysis demo with technical comments](Smart State Analysis demo with technical comments: https://www.youtube.com/watch?v=Uc5kTSdVNZA)
+[Smart State Analysis demo with technical comments](https://www.youtube.com/watch?v=Uc5kTSdVNZA "Smart State Analysis demo with technical comments")
 
 ### Containers Metrics
 


### PR DESCRIPTION
As per subject, the markdown syntax for the anchor was wrong.