### PR TITLE
Improve readability by disabling Style/TrailingUnderscoreVariable

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -214,6 +214,8 @@ Style/TrailingCommaInArguments:
   Enabled: false
 Style/TrailingCommaInLiteral:
   Enabled: false
+Style/TrailingUnderscoreVariable:
+  Enabled: false
 Style/TrivialAccessors:
   AllowPredicates: true
 Style/WhileUntilModifier:


### PR DESCRIPTION
When enabled, it will output the following:
```
test.rb:1:7: C: Do not use trailing _s in parallel assignment. Prefer a, b, = 1, 2, 3, 4.
a, b, _, _ = 1, 2, 3, 4
      ^^^^^
```

Thanks for mentioning this one @carbonin 