### PR TITLE
Mention Yarn package manager in Mac install section

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -133,10 +133,10 @@
   brew install node
   ```
 
-* Install the _Bower_ package manager
+* Install the _Bower_ and _Yarn_ package manager
 
   ```
-  npm install -g bower
+  npm install -g bower yarn
   ```
 
 * Configure and start PostgreSQL


### PR DESCRIPTION
[This commit](https://github.com/ManageIQ/manageiq-ui-classic/commit/97d1db23a5d037f8f971955a82ee67cfc0434ec9) introduced a new Rake task to install/update packages via Yarn package manager.

The guides were updated in Fedora/CentOS 7 and Ubuntu/Debian sections to mention Yarn package manager in their install procedures. Section for Mac OS X, however wasn't updated. This patch adds the missing info.