### PR TITLE
Update developer_setup with correct libssl-dev name from apt

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -83,7 +83,7 @@
   sudo apt install libcurl4-gnutls-dev              # For Curb
   sudo apt install cmake                            # For rugged Gem
   sudo apt install libgit2-dev pkg-config libtool
-  sudo apt install libssl1.0-dev                    # for puma < 3.7.0
+  sudo apt install libssl-dev                    # for puma < 3.7.0
   ```
 
 * Install the _Bower_ package manager


### PR DESCRIPTION
The libssl1.0-dev is no longer in the apt repositories


```bash
$ sudo apt install libssl1.0-dev gives
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package libssl1.0-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libssl1.0-dev' has no installation candidate
```

When installing libssl-dev, libssl it resolves to libssl1.0.2-dev and works fine.

I hope the explanation is sufficient- if not, please let me know what additional information should I supply
