### PR TITLE
Disable DoubleNegation cop

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -49,6 +49,8 @@ Style/CollectionMethods:
     reduce: inject
 Style/Documentation:
   Enabled: false
+Style/DoubleNegation:
+  Enabled: false
 Style/EmptyMethod:
   Enabled: false
 Style/Encoding:


### PR DESCRIPTION
Disables the [cop that declares the use of double negatives (`!!`) always bad.](http://www.rubydoc.info/gems/rubocop/0.47.1/RuboCop/Cop/Style/DoubleNegation)

Double negatives are useful for forcing values/`nil` to a boolean value as a return value.

Rather than pontificate on why they should be allowed, I'll just point out that this change is basically a formality and I believe shouldn't merit a ton of distracting debate as we already knowingly use and prefer double negatives in our codebase:

* https://github.com/ManageIQ/manageiq/issues/11954
* https://github.com/ManageIQ/manageiq-api/pull/59
* (More I can't find)

cc/ @imtayadeway