### PR TITLE
Use https remote url when setting up upstream for manageiq-ui-classic

### DIFF
--- a/developer_setup/plugins.md
+++ b/developer_setup/plugins.md
@@ -52,7 +52,7 @@ cd manageiq-ui-classic
 git remote -v
 # origin  git@github.com:JoeSmith/manageiq-ui-classic.git (fetch)
 # origin  git@github.com:JoeSmith/manageiq-ui-classic.git (push)
-git remote add upstream git@github.com:ManageIQ/manageiq-ui-classic
+git remote add upstream https://github.com/ManageIQ/manageiq-ui-classic.git
 git fetch upstream
 # merge upstream into your fork
 git checkout master


### PR DESCRIPTION
**Description**

While setting up my environment, I copied that line and got an error, because ssh remote urls only work for people with commit access.
It's better to use the https url in a guide that is probably mostly intended for people without commit access.