### PR TITLE
Add link to CONTRIBUTING.md in API Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 * [Roadmap and Sprints](https://github.com/ManageIQ/manageiq/milestones)
 * [Updating this Documentation](writing_guides.md)
 * [Developing using a Vagrant VM](vagrant_developer_vm.md)
+* [Contributing to the API](https://github.com/ManageIQ/manageiq-api/blob/master/CONTRIBUTING.md)
 
 ### ManageIQ technical documentation
 * [Architecture](architecture.md)


### PR DESCRIPTION
Link to the API repo’s contributor’s guide to ensure it is always the most up to date version.