### PR TITLE
Add 'use yum' advice notice for CentOS users

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -4,7 +4,7 @@
 
 #### Fedora / CentOS 7
 
-* CentOS only - Enable EPEL & install DNF
+* CentOS only - dnf is no longer available on CentOS7. In the examples below, replace dnf with yum
 
   ```bash
   sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -4,12 +4,7 @@
 
 #### Fedora / CentOS 7
 
-* CentOS only - dnf is no longer available on CentOS7. In the examples below, replace dnf with yum
-
-  ```bash
-  sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  sudo yum -y install dnf
-  ```
+* CentOS only - dnf is no longer available on CentOS 7. In the examples below, replace dnf with yum.
 
 * Install Packages
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -4,7 +4,7 @@
 
 #### Fedora / CentOS 7
 
-* CentOS only - dnf is no longer available on CentOS 7. In the examples below, replace dnf with yum.
+* CentOS only - use yum instead of dnf.
 
 * Install Packages
 


### PR DESCRIPTION
`dnf` is no longer available for CentOS 7 users. Advise users to use `yum` instead.