### PR TITLE
Override the default overrides

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -199,7 +199,10 @@ Style/NumericLiterals:
   AutoCorrect: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    default: '()'
+    '%i': ()
+    '%I': ()
+    '%w': ()
+    '%W': ()
 Style/PerlBackrefs:
   Enabled: false
 Style/ParallelAssignment:


### PR DESCRIPTION
Get back to our previous defaults

Based on https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L1224-L1234