### PR TITLE
Ignore manageiq fixture path and vendor path

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -1,4 +1,7 @@
 AllCops:
+  Exclude:
+    - spec/manageiq/**/*
+    - vendor/**/*
   TargetRubyVersion: 2.3
 Lint/DefEndAlignment:
   AutoCorrect: true


### PR DESCRIPTION
Running rubocop locally on a ManageIQ plugin will check the
spec/manageiq and vendor paths unless explicitly ignored, resulting in
1000s of lines of unnecessary output.