### PR TITLE
use illustrating percent array literal

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -199,10 +199,11 @@ Style/NumericLiterals:
   AutoCorrect: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%i': ()
-    '%I': ()
-    '%w': ()
-    '%W': ()
+    default: '[]'
+    '%i': '[]'
+    '%I': '[]'
+    '%w': '[]'
+    '%W': '[]'
 Style/PerlBackrefs:
   Enabled: false
 Style/ParallelAssignment:


### PR DESCRIPTION
I don't know why the round brackets were chosen instead of the square ones, maybe there was some weighty reason?

However, I propose to use square brackets - because it looks the same as the basic array literal:
```ruby
[:a, :b] == %i[a b]
```
I believe it will make the code more readable.