### PR TITLE
Rubocop base - set Style/FormatStringToken back to template

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -66,6 +66,8 @@ Style/Encoding:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: percent
+Style/FormatStringToken:
+  EnforcedStyle: template
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:


### PR DESCRIPTION
with the upgrade of rubocop, it changed to the new `annotate` default, causing a lot of warnings like..

```
Style/FormatStringToken - Prefer annotated tokens (like %<foo>s) over template tokens (like %{foo}).
```

(example: https://github.com/ManageIQ/manageiq-ui-classic/pull/3378#issuecomment-363461332)

[docs](http://www.rubydoc.info/gems/rubocop/0.52.0/RuboCop/Cop/Style/FormatStringToken)