### PR TITLE
Clarify the N_ new syntax example

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -183,7 +183,7 @@ Sometimes we need to delay translation of a string to a later time. For example 
 In the simplest case you can use `N_('bar')` saying "do not translate this string" such as:
 
 ```ruby
-menu_item = Menu::Item.new(N_('Cloud Tennants')
+menu_item = Menu::Item.new(N_('Cloud Tennants'))
 ```
 
 and such strings will be caught by the `rake gettext:find` task so these strings end up in the catalog.


### PR DESCRIPTION
Fixes a syntax issue in one of the N_ examples.