### PR TITLE
Fix errors with out of date comma cops

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -232,7 +232,9 @@ Style/StringLiteralsInInterpolation:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false


### PR DESCRIPTION
This prevents rubocop from running properly.

Error in question:

```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml, please update it)
```

Updated to use both cops to retain the same functionality.


Links
-----

* Changed in `rubocop` here:  https://github.com/bbatsov/rubocop/pull/5307
* Original `rubocop` rational:  https://github.com/bbatsov/rubocop/issues/3394