### PR TITLE
No parens required for warn

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -107,6 +107,7 @@ Style/MethodCallWithArgsParentheses:
     - require
     - sleep
     - throw
+    - warn
     - yield
     # Rails
     - accepts_nested_attributes_for


### PR DESCRIPTION
`warn` is similar to `puts`, so treat them the same in `rubocop`'s eyes and have it not require parenthesis.