### PR TITLE
Updates Rubocop rules to add compatibility with versions 0.53.0+

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -233,7 +233,9 @@ Style/StringLiteralsInInterpolation:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false


### PR DESCRIPTION
At [version`0.53.0`](https://github.com/bbatsov/rubocop/blob/3c3e315b84df45845440a25cbd71a5b99214b21d/CHANGELOG.md#0530-2018-03-05), the `TrailingCommaInLiteral` rule at Rubocop has been split into`TrailingCommaInHashLiteral` and `TrailingCommaInArrayLiteral` and no longer exists. The current version definition for Rubocop allow us to use the version `0.52.1` or superior, but it is not possible to have both versions by having that options in your `rubocop.yml` file.

Thus, we have to choose between using a version lower than `0.53.0` or using a superior version and update our rules. The current suggestion updates the rules list in order to have compatibility with `0.53.0+`.

This problem can be seen at https://github.com/ManageIQ/manageiq-ui-classic/ project, that uses the Gemfile in the core project in its build process.

Depends on:
- https://github.com/ManageIQ/manageiq/pull/17327
