### PR TITLE
rubocop - don't check for NumericPredicate

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -206,6 +206,8 @@ Style/MethodCallWithArgsParentheses:
     - task
 Style/NumericLiterals:
   AutoCorrect: false
+Style/NumericPredicate:
+  AutoCorrect: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': ()


### PR DESCRIPTION
This is questioning the following assertion
It may make sense to use `.zero?`, but don't feel that should be stated / requested from rubocop

```ruby
# bad

foo == 0
0 > foo
bar.baz > 0

# good

foo.zero?
foo.negative?
bar.baz.positive?
```

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericPredicate

I don't have major opinion here, but the request was annoying.