### PR TITLE
Set Style/RescueStandardError to implicit

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -224,6 +224,8 @@ Style/RegexpLiteral:
   Enabled: false
 Style/RescueModifier:
   AutoCorrect: false
+Style/RescueStandardError:
+  EnforcedStyle: implicit
 Style/SignalException:
   EnforcedStyle: only_raise
 Style/SingleLineBlockParams:


### PR DESCRIPTION
Most of the code base is already in implicit mode, but rubocop changed
their default to explicit.  This moves it back for consistency as well
as my personal preference :)

https://www.rubydoc.info/gems/rubocop/0.52.1/RuboCop/Cop/Style/RescueStandardError

Please vote on what you prefer with 👍  or 👎  on this comment  (:+1: means you want implicit like this PR; :-1: means you want explicit as per the rubocop default)