### PR TITLE
Redfish - add mock provider setup instructions

### DIFF
--- a/providers/redfish.md
+++ b/providers/redfish.md
@@ -1,0 +1,7 @@
+### Redfish
+
+It seems no actual provider instances are available, but a static recording + a mock server *is* available:
+
+* [redfish-recordings](https://github.com/xlab-si/redfish-recordings)
+
+That repository also contains short instructions on how to get the server running.


### PR DESCRIPTION
Instructions courtesy of @tadeboro (from https://github.com/ManageIQ/manageiq-ui-classic/pull/3912), thanks!

These are just instructions on setting up a mock version of yet another provider - https://github.com/ManageIQ/manageiq-providers-redfish