### PR TITLE
Update documentation on host-based authentication

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -40,8 +40,11 @@
 
   ```bash
   sudo postgresql-setup initdb
-  sudo grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
-  sudo sed -i.bak 's/\(^local\s*\w*\s*\w*\s*\)\(peer$\)/\1trust/' /var/lib/pgsql/data/pg_hba.conf
+  sudo cp /var/lib/pgsql/data/pg_hba.conf /var/lib/pgsql/data/pg_hba.conf.bak
+  cat <<EOF | sudo tee /var/lib/pgsql/data/pg_hba.conf
+  local   all             all                                     trust
+  host    all             root            127.0.0.1/32            trust
+  EOF
   sudo systemctl enable postgresql
   sudo systemctl start postgresql
   sudo -u postgres psql -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"


### PR DESCRIPTION
Currently, developer setup docs fail to mention that tests also
require non-local access to PostgreSQL, which in turn causes those
tests to fail.

This commit remedies this situation by updating the PostgreSQL
configuration section of the docs with working pg_hba.conf file.