### PR TITLE
Update UI test docs

### DIFF
--- a/developer_setup/running_test_suites.md
+++ b/developer_setup/running_test_suites.md
@@ -128,8 +128,9 @@ file contains a block like this:
 
     override_gem "manageiq-ui-classic", path: "/home/u/miq/manageiq-ui-classic"
 
-Now you must run `bin/update` from the `/home/u/miq/manageiq` folder, followed
-by `bin/update` from the `/home/u/miq/manageiq-ui-classic` folder.
+Now you must run `bin/update` from the
+`/home/u/miq/manageiq-ui-classic/spec/manageiq` folder, followed by
+`bin/update` from the `/home/u/miq/manageiq-ui-classic` folder.
 
 After all this is done, you can run tests as usual:
 


### PR DESCRIPTION
Instructions for running UI specs had a bad path in it, causing
`bin/update` in UI folder to fail with a message

    The git source https://github.com/ManageIQ/manageiq-gems-pending.git
    is not yet checked out. Please run `bundle install` before trying to
    start your application

This commit simply fixes this typo.