### PR TITLE
Ignore references & index methods for parentheses

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -154,8 +154,10 @@ Style/MethodCallWithArgsParentheses:
     - has_one
     - head
     - identified_by
+    - index
     - integer
     - mattr_accessor
+    - references
     - remove_column
     - remove_index
     - rename_column


### PR DESCRIPTION
Ignore migration methods (references and index) for the rubocop MethodCallWithArgsParentheses cop.

Ref: https://github.com/ManageIQ/manageiq-schema/pull/242#issuecomment-412886651