### PR TITLE
Don't require parens around add_reference

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -113,6 +113,7 @@ Style/MethodCallWithArgsParentheses:
     - accepts_nested_attributes_for
     - add_column
     - add_index
+    - add_reference
     - after_action
     - after_commit
     - after_create


### PR DESCRIPTION
Parentheses shouldn't be required around add_reference, see https://github.com/ManageIQ/manageiq-schema/pull/258#issuecomment-415752604

Follow up to https://github.com/ManageIQ/guides/pull/326