### PR TITLE
Removed old tags which cause failures when running locally

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -12,9 +12,9 @@ Layout/SpaceBeforeFirstArg:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   AutoCorrect: true
-Lint/EndAlignment:
+Layout/EndAlignment:
   AutoCorrect: true
 Metrics/AbcSize:
   Enabled: false
@@ -242,7 +242,9 @@ Style/StringLiteralsInInterpolation:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false


### PR DESCRIPTION
When running locally we see these errors

```
.rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml: Lint/DefEndAlignment has the wrong namespace - should be Layout
.rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml: Lint/EndAlignment has the wrong namespace - should be Layout
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml, please update it)
```