### PR TITLE
Reference Optimist

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -181,7 +181,7 @@ Style/MethodCallWithArgsParentheses:
     # DefaultValue Gem
     - default_value_for
     - default_values
-    # Trollop Gem
+    # Optimist Gem
     - banner
     - die
     - opt


### PR DESCRIPTION
`Trollop` is a deprecated gem, and has been renamed/replaced by `Optimist`.

While not really needed here, just a good idea to avoid future confusion for those who don't know the history of the change.

Links
-----
* Org search of current usage of old gem (hides some irrelevant repos):  [search](https://github.com/search?l=&q=Trollop+repo%3AManageIQ%2Fmanageiq+repo%3AManageIQ%2Fmanageiq-release+repo%3AManageIQ%2Fmanageiq-appliance_console+repo%3AManageIQ%2Fmanageiq-appliance-build+repo%3AManageIQ%2Fmanageiq-api+repo%3AManageIQ%2Fmanageiq-providers-vmware+repo%3AManageIQ%2Fhttpd_configmap_generator+repo%3AManageIQ%2Fguides&type=Code)