### PR TITLE
Disable Style/SymbolArray and Style/WordArray

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -240,6 +240,8 @@ Style/StringLiterals:
   Enabled: false
 Style/StringLiteralsInInterpolation:
   Enabled: false
+Style/SymbolArray:
+  Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false
 Style/TrailingCommaInLiteral:
@@ -251,4 +253,4 @@ Style/TrivialAccessors:
 Style/WhileUntilModifier:
   Enabled: false
 Style/WordArray:
-  AutoCorrect: false
+  Enabled: false

--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -212,12 +212,6 @@ Style/NumericLiterals:
   AutoCorrect: false
 Style/NumericPredicate:
   AutoCorrect: false
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%i': ()
-    '%I': ()
-    '%w': ()
-    '%W': ()
 Style/PerlBackrefs:
   Enabled: false
 Style/ParallelAssignment:


### PR DESCRIPTION
This change allows the use of either style of word arrays:

```ruby
["foo", "bar", "baz"] # both valid
%w[foo bar baz]
```

And symbol arrays:

```ruby
[:foo, :bar, :baz]    # both valid
%i[foo bar baz]
```

The style of symbol/word arrays will still be enforced, but will change in the future to match the defaults from `rubocop`.  Currently `%i()` and `%w()`, but will change to `%i[]` and `%w[]` in a future PR.