### PR TITLE
add iproute2mac tool for appliance_console devs

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -120,6 +120,7 @@
   brew install cmake
   brew install node
   brew install yarn
+  brew install iproute2mac
   ```
 
   If your node version is less than the [required version](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/package.json), you may need to `brew upgrade node` and `brew link node`.


### PR DESCRIPTION
The console looks up ip addresses. This uses the `ip` command.
While it is not available on native macs, homebrew does have a wrapper.

```
  1) ManageIQ::ApplianceConsole::Cli#set_replication should configure repmgrd when auto-failover flag is set
     Failure/Error: self.primary_host      = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE).address

     AwesomeSpawn::NoSuchFileError:
       No such file or directory - addr
     # gems/awesome_spawn-1.4.1/lib/awesome_spawn.rb:81:in `rescue in run'
```

After this install, tests pass in the appliance console.

Thank you open source.