### PR TITLE
Add remove_reference to the rubocop exclusions

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -163,6 +163,7 @@ Style/MethodCallWithArgsParentheses:
     - references
     - remove_column
     - remove_index
+    - remove_reference
     - rename_column
     - render
     - require_dependency


### PR DESCRIPTION
Add `#remove_reference` to the list of rubocop exclusions for the `Style/MethodCallWithArgsParentheses` cop.

Ref: https://github.com/ManageIQ/topological_inventory-core/pull/104