### PR TITLE
Update rubocop rules to new Rubocop.

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -12,9 +12,9 @@ Layout/SpaceBeforeFirstArg:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   AutoCorrect: true
-Lint/EndAlignment:
+Layout/EndAlignment:
   AutoCorrect: true
 Metrics/AbcSize:
   Enabled: false
@@ -236,9 +236,9 @@ Style/StringLiterals:
   Enabled: false
 Style/StringLiteralsInInterpolation:
   Enabled: false
-Style/TrailingCommaInArguments:
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false


### PR DESCRIPTION
Update rules to work with Rubocop 0.65.0.