### PR TITLE
Guide for installing a stable node on mac

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -116,7 +116,7 @@
   brew install git
   brew install pkg-config
   brew install memcached
-  brew install postgresql
+  brew install postgresql@9.5
   brew install cmake
   brew install node
   brew install yarn
@@ -125,6 +125,16 @@
 
   If your node version is less than the [required version](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/package.json), you may need to `brew upgrade node` and `brew link node`.
   Or you may be able to use [nvm](https://github.com/creationix/nvm).
+
+  If your node version is 9 (the odd numbers are unstable) then some packages may not install properly.
+  You may need to downgrade node:
+
+  ```bash
+  brew uninstall node yarn
+  brew install node@8
+  brew link node@8 # --force --overwrite
+  brew install yarn
+  ```
 
 * Configure and start PostgreSQL
   * Required PostgreSQL version is 9.5


### PR DESCRIPTION
Fixes an error while running `bin/update`.
Under the covers it was failing from task `rake update:ui`

```
ERROR in ./node_modules/spin.js/spin.css (
./node_modules/css-loader??ref--8-1!
./node_modules/postcss-loader/lib??ref--8-2!
./node_modules/resolve-url-loader!
./node_modules/sass-loader/lib/loader.js??ref--8-4!
./node_modules/spin.js/spin.css)

Module build failed (from ./node_modules/sass-loader/lib/loader.js):
Error: Node Sass does not yet support your current environment:
OS X 64-bit with Unsupported runtime (67)

For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v4.9.4
```

Apparently odd numbers for node are unstable, so I needed to downgrade from v9 to v8

/cc @himdel 