### PR TITLE
provider_plugin - drop :button from example

### DIFF
--- a/ui/provider_plugin.md
+++ b/ui/provider_plugin.md
@@ -44,7 +44,6 @@ module ManageIQ
               t,
               :data  => {'function'      => 'sendDataWithRx',
                          'function-data' => {:controller     => 'provider_dialogs', # this one is required
-                                             :button         => :magic,
                                              :modal_title    => N_('Create a Security Group'),   # title of modal displaying the form
                                              :component_name => 'CreateAmazonSecurityGroupForm', # name of React component implementing the form
                                               }.to_json},
@@ -99,7 +98,6 @@ module ManageIQ
               t,
               :data  => {'function'      => 'sendDataWithRx',
                          'function-data' => {:controller  => 'provider_dialogs', 	      # this one is required
-                                             :button      => :magic_player,
                                              :dialog_name => 'test',		 	      # name of dialog
                                              :dialog_title => N_('Magic Provider Dialog'),    # title of modal displaying the form (dialog)
                                              :class       => 'ManageIQ::Providers::Amazon',   # namespace of this provider


### PR DESCRIPTION
There is no code in `app/javascript/packs/provider-dialogs-common.js` that would look at `buttonData.button`.

This was either an artefact of development, or originally used for extra props, removing to prevent confusion.

Cc @martinpovolny 