### PR TITLE
Update rules to work with Rubocop 0.69.

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -12,9 +12,9 @@ Layout/SpaceBeforeFirstArg:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   AutoCorrect: true
-Lint/EndAlignment:
+Layout/EndAlignment:
   AutoCorrect: true
 Metrics/AbcSize:
   Enabled: false
@@ -240,9 +240,9 @@ Style/StringLiteralsInInterpolation:
   Enabled: false
 Style/SymbolArray:
   Enabled: false
-Style/TrailingCommaInArguments:
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false


### PR DESCRIPTION
Update rules to work with Rubocop 0.69.0.

Replacement for 
https://github.com/ManageIQ/guides/pull/343