### PR TITLE
Add explicit require for rubocop-performance

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   Exclude:
     - spec/manageiq/**/*


### PR DESCRIPTION
Starting in version 0.68 the performance cops were split out into their own gem called `rubocop-performance`. It has to be explicitly required or we'll start getting these:

`Warning: unrecognized cop Performance/Casecmp found in .rubocop.yml`