### PR TITLE
Change default preferred exception name to 'err'

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -38,6 +38,8 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Performance/Casecmp:
   Enabled: false
 Rails:


### PR DESCRIPTION
As of rubocop 0.5.3, they added the rule `Naming/RescuedExceptionsVariableName`. This checks the variable name assigned to exceptions when you do something like this:

`rescue StandardError => err # <== I'm talking about 'err' here`

It's a nice idea in theory. Unfortunately, they chose a default preferred value of "e", which means that any other variable name will generate a rubocop warning about the exception name.

I think violates the whole "meaningful variable names" concept. I think "err" hits the sweet spot between meaningful and concise, so I'm suggesting this tweak.

Edit: in fact, it violates their *own* default variable naming enforcement for the also-new `Naming/UncommunicativeMethodParamName` option, which defaults to a minimum of 3 characters.

If you said "either/or" I'll count one vote for each.

Vote tally:

* Use `err`: 3
* Use `error`: 2
* Just stick with `e`: 1
* Disable the cop: 4

Update: Now it's just disabled since that seems to have the edge in the voting.