### PR TITLE
Rewrite developer guide

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -2,13 +2,13 @@
 
 ### Requirements Summary
 
-|         |         |
-| ------- | ------- |
-| Ruby    | 2.4.x   |
-| Rails   | 5.1.x   |
-| Bundler | 1.16.x  |
-| NodeJS  | 10.16.x |
-| Python  | 2.7.x   |
+| **Name** | **Version** |
+| -------- | ----------- |
+| Ruby     | 2.4.x       |
+| Rails    | 5.1.x       |
+| Bundler  | 1.16.x      |
+| NodeJS   | 10.16.x     |
+| Python   | 2.7.x       |
 
 ## Build Requirements
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -80,7 +80,7 @@ Install postgresql:
 CentOS 7 ships PostgreSQL 9.x. In order to use PostgreSQL 10.x, you will need to [enable Software Collections](https://www.softwarecollections.org/en/docs/) and install `rh-postgresql10`.
 
 ```bash
-sudo yum -y remove postgresql-devel
+sudo yum -y autoremove postgresql-devel
 sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postgresql10-postgresql-devel
 ```
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -87,7 +87,7 @@ sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postg
 
 ---
 
-Configure the cluster.
+#### Configure the cluster
 
 On Fedora and CentOS, configure a cluster using `postgresql-setup`.
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -81,7 +81,7 @@ CentOS 7 ships PostgreSQL 9.x. In order to use PostgreSQL 10.x, you will need to
 
 ```bash
 sudo yum -y autoremove postgresql-devel
-sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postgresql10-postgresql-devel
+sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postgresql10-postgresql-devel rh-postgresql10-postgresql-server-syspaths
 ```
 
 ---

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -131,10 +131,6 @@ nvm install 10
 npm install -g yarn gulp-cli webpack
 ```
 
-## Clone the project
-
-`git clone git@github.com:ManageIQ/manageiq.git`
-
 ## Install Ruby and Bundler
 
 A Ruby version manager is *strongly* recommended. Use any one of the following:
@@ -144,6 +140,13 @@ A Ruby version manager is *strongly* recommended. Use any one of the following:
 * [chruby](https://github.com/postmodern/chruby)
 
 Using the Ruby version manager, install `ruby` >= 2.4.0 and < 2.6.0 and `bundler` >= 1.16.
+
+## Clone the project
+
+```bash
+git clone git@github.com:ManageIQ/manageiq.git
+cd manageiq
+```
 
 ## Configure Project Manually
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -125,7 +125,7 @@ brew services start postgresql
 
 ## Install nvm and JavaScript build utilities
 
-Yarn, Gulp and Webpack are required to compile JavaScript assets. NodeJS version 10.16.x is required. If your distribution doesn't ship NodeJS 10.x, you can install [nvm](https://github.com/nvm-sh/nvm) and follow the setup steps. Then install `yarn`, `gulp-cli` and `webpack`.
+Yarn, Gulp and Webpack are required to compile JavaScript assets. NodeJS version 10.16.x is required. If your distribution doesn't ship NodeJS 10.x, you can install [nvm](https://github.com/nvm-sh/nvm) and follow the setup steps (you will need to restart your shell in order to source the nvm initialization environment). Then install `yarn`, `gulp-cli` and `webpack`.
 
 ```bash
 nvm install 10
@@ -149,49 +149,22 @@ git clone git@github.com:ManageIQ/manageiq.git
 cd manageiq
 ```
 
-## Configure Project Manually
+## Configure Project
 
-All the steps below are wrapped inside the `bin/setup` script, but they are outlined here to explain how to completely bootstrap a developer environment. If you've run PostgreSQL in a container, be sure to export the `DATABASE_URL` variable to connect to the container over TCP instead of a UNIX file socket.
+---
+**NOTE**
+
+macOS requires platform specific Gems. Run `bundle config specific_platform true` before running `setup`.
+
+CentOS 7 requires the `rh-postgresql10` SCL environment in order to compile the `pq` Gem's native extensions. Run `setup` inside the `scl` environment: `scl enable rh-postgresql10 'bin/setup'`.
+
+If you've run PostgreSQL in a container, be sure to export the `DATABASE_URL` variable to connect to the container over TCP instead of a UNIX file socket.
 
 ```bash
 export DATABASE_URL='posgresql://localhost:5432' # optional, only necessary if PostgreSQL is running in a container
 ```
 
-### Create neccessary config files
-
-In order to run the application locally, a few sample config files need to be copied into their appropriate locations.
-
-```bash
-[[ -f "certs/v2_key" ]] || cp "certs/v2_key.dev" "certs/v2_key"
-[[ -f "config/cable.yml" ]] || cp "config/cable.yml.sample" "config/cable.yml"
-[[ -f "config/database.yml" ]] || cp "config/database.pg.yml" "config/database.yml"
-mkdir -p log
-```
-
-### Install Bundler and Gems
-
 ---
-**NOTE**
-
-macOS requires platform specific Gems. Run `bundle config specific_platform true` before installing.
-
-CentOS 7 requires the `rh-postgresql10` SCL environment in order to compile the `pq` Gem's native extensions. Run `bundle install` inside the `scl` environment: `scl enable rh-postgresql10 'bundle install'`.
-
----
-
-```bash
-gem install bundler --version 1.16 --conservative
-bundle config specific_platform true # optional for non-macOS platforms
-bundle install
-bundle exec rails update:ui
-bundle exec rails db:create
-bundle exec rails db:migrate
-bundle exec rails db:seed
-bundle exec rails test:vmdb:setup
-bundle exec rails log:clear tmp:clear
-```
-
-## Configure Project Automatically
 
 ```bash
 bin/setup

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -151,7 +151,7 @@ cd manageiq
 
 ## Configure Project
 
-A Ruby script called `setup` is available to quickly set up the application. This script installs the required Gems, sets up necessary JavaScript libraries, creates and migrates the database, and finally seeds the database with development content.
+A Ruby script called `setup` is available to quickly set up the application. This script installs the required Gems, sets up necessary JavaScript libraries, creates and migrates the database, and finally seeds the database with initial content.
 
 ---
 **NOTE**

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -77,7 +77,7 @@ Configure, enable and start the service.
 Using systemd:
 
 ```bash
-sudo postgresql-setup initdb --auth trust --username root --encoding UTF-8 --locale C
+su -c postgres 'initdb --auth trust --username root --encoding UTF-8 --locale C /var/lib/pgsql/data'
 systemctl enable --now postgres
 ```
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -1,323 +1,175 @@
-## Developer Setup
+# New Developer Setup
 
-### Install System Packages
+### Requirements Summary
 
-#### Fedora / CentOS 7
+| Ruby    | 2.4.x   |
+| Rails   | 5.1.x   |
+| Bundler | 1.16.x  |
+| NodeJS  | 10.16.x |
+| Python  | 2.7.x   |
 
-* CentOS only - use yum instead of dnf.
+## Build Requirements
 
-* Install Packages
+In order to compile Ruby, native Gems and native NodeJS modules, GCC and its related utilities are required. Depending on your Linux distribution, package names may vary slightly.
 
-  ```bash
-  sudo dnf -y group install "C Development Tools and Libraries"  # For unf Gem and noi4r Gem
-  sudo dnf -y install git-all                                    # Git and components
-  sudo dnf -y install memcached                                  # Memcached for the session store
-  sudo dnf -y install postgresql-devel postgresql-server         # PostgreSQL Database server and to build 'pg' Gem
-  sudo dnf -y install bzip2 libffi-devel readline-devel          # For rbenv install 2.3.1 (might not be needed with other Ruby setups)
-  sudo dnf -y install libxml2-devel libxslt-devel patch          # For Nokogiri Gem
-  sudo dnf -y install sqlite-devel                               # For sqlite3 Gem
-  sudo dnf -y install nodejs                                     # For ExecJS Gem, bower, npm, yarn, webpack..
-  sudo dnf -y install libcurl-devel                              # For Curb
-  rpm -q --whatprovides npm || sudo dnf -y install npm           # For CentOS 7, Fedora 23 and older
-  sudo dnf -y install openssl-devel                              # For rubygems
-  sudo dnf -y install cmake                                      # For rugged Gem
-  sudo dnf -y install openscap                                   # Optional, for openscap Gem for container SSA
-  ```
+* Using dnf: `sudo dnf -y install @c-development libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
+* Using yum: `sudo yum -y group install "C Development Tools and Libraries" libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
+* Using apt: `sudo apt -y install build-essential libffi-dev libpq-dev libxml2-dev libcurl-dev cmake libsqlite3-dev python`
+* Using brew: `brew install cmake`
 
-  If your node version is less than the [required version](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/package.json), you can use [nvm](https://github.com/creationix/nvm) to install a node version locally (similar to `rbenv`).
+To ensure the appropriate extensions are built when Ruby is compiled, install the header files for OpenSSL, readline and zlib.
 
-* Enable Memcached
+* Using dnf: `sudo dnf -y install openssl-devel readline-devel zlib-devel`
+* Using yum: `sudo yum -y install openssl-devel readline-devel zlib-devel`
+* Using apt: `sudo apt -y install libssl-dev libreadline-dev libz-dev`
+* Using brew: `brew install openssl`
 
-  ```bash
-  sudo systemctl enable memcached
-  sudo systemctl start memcached
-  ```
+## Service Requirements
 
-* Configure PostgreSQL
-  * Required PostgreSQL version is 10
-    * See [here](developer_setup/postgresql_software_collection.md) how to install
-      it in Linux distributions like CentOS 7, using _SoftwareCollections.org_.
-    * Or follow the directions [here](https://www.postgresql.org/download/linux/redhat/#yum)
-      to install it from the PostgreSQL Global Development Group repositories.
+ManageIQ requires a memcached instance for session caching and a PostgreSQL database for persistent data storage.
 
-  ```bash
-  sudo postgresql-setup initdb
-  sudo grep -q '^local\s' /var/lib/pgsql/data/pg_hba.conf || echo "local all all trust" | sudo tee -a /var/lib/pgsql/data/pg_hba.conf
-  sudo sed -i.bak 's/\(^local\s*\w*\s*\w*\s*\)\(peer$\)/\1trust/' /var/lib/pgsql/data/pg_hba.conf
-  sudo systemctl enable postgresql
-  sudo systemctl start postgresql
-  sudo -u postgres psql -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
-  # This command can return with a "could not change directory to" error, but you can ignore it
-  ```
+### Containers
 
-#### Ubuntu / Debian
-
-* Install Packages
-
-  ```bash
-  sudo apt install git                              # Git and components
-  sudo apt install memcached                        # Memcached for the session store
-  sudo apt install postgresql libpq-dev             # PostgreSQL Database server and to build 'pg' Gem
-  sudo apt install bzip2 libffi-dev libreadline-dev # For rbenv install 2.3.1 (might not be needed with other Ruby setups)
-  sudo apt install libxml2-dev libxslt-dev patch    # For Nokogiri Gem
-  sudo apt install libsqlite-dev libsqlite3-dev     # For sqlite3 Gem
-  sudo apt install nodejs nodejs-legacy npm         # For ExecJS Gem, bower, npm, yarn, webpack..
-  sudo apt install g++                              # For unf Gem
-  sudo apt install libcurl4-gnutls-dev              # For Curb
-  sudo apt install cmake                            # For rugged Gem
-  sudo apt install libgit2-dev pkg-config libtool
-  sudo apt install libssl-dev                       # for puma < 3.7.0
-  ```
-
-  If your node version is less than the [required version](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/package.json), you can either install it from the `experimental` repo:
-
-  ```bash
-  echo 'deb http://ftp.debian.org/debian/ experimental main non-free contrib' | sudo tee /etc/apt/sources.list.d/experimental.list
-  sudo apt update
-  sudo apt install nodejs nodejs-legacy npm
-  ```
-
-  Alternatively, you can use [nvm](https://github.com/creationix/nvm) to install a node version locally (similar to `rbenv`).
-
-* Ubuntu fix for failing Bundler
-
-  ```bash
-  sudo apt remove libssl-dev
-  wget http://ftp.cz.debian.org/debian/pool/main/o/openssl1.0/libssl1.0-dev_1.0.2l-2_amd64.deb
-  wget http://ftp.cz.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.2l-2_amd64.deb
-  sudo dpkg -i libssl1.0-dev_1.0.2l-2_amd64.deb libssl1.0.2_1.0.2l-2_amd64.deb
-  ```
-
-* Enable Memcached
-
-  ```bash
-  sudo systemctl enable memcached
-  sudo systemctl start memcached
-  ```
-
-* Configure PostgreSQL
-
-  ```bash
-  sudo grep -q '^local\s' /etc/postgresql/10/main/pg_hba.conf || echo "local all all trust" | sudo tee -a /etc/postgresql/10/main/pg_hba.conf
-  sudo sed -i.bak 's/\(^local\s*\w*\s*\w*\s*\)\(peer$\)/\1trust/' /etc/postgresql/10/main/pg_hba.conf
-  sudo systemctl restart postgresql
-  sudo su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
-  ```
-
-#### Mac
-
-* Install [Homebrew](http://brew.sh/)
-
-  If you do not have Homebrew installed, go to the Homebrew website and install it.
-
-* Install Packages
-
-  ```bash
-  brew install git
-  brew install pkg-config
-  brew install memcached
-  brew install postgresql@10
-  brew install cmake
-  brew install node
-  brew install yarn
-  brew install iproute2mac
-  ```
-
-  If your node version is less than the [required version](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/package.json), you may need to `brew upgrade node` and `brew link node`.
-  Or you may be able to use [nvm](https://github.com/creationix/nvm).
-
-  If your node version is 9 (the odd numbers are unstable) then some packages may not install properly.
-  You may need to downgrade node:
-
-  ```bash
-  brew uninstall node yarn
-  brew install node@8
-  brew link node@8 # --force --overwrite
-  brew install yarn
-  ```
-
-* Configure and start PostgreSQL
-  * Required PostgreSQL version is 10
-
-  ```bash
-  # Enable PostgreSQL on boot
-  mkdir -p ~/Library/LaunchAgents
-  ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
-  launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
-  # Create the ManageIQ superuser
-  psql -d postgres -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"
-  ```
-
-* Start memcached
-
-  ```bash
-  # Enable Memcached on boot
-  ln -sfv /usr/local/opt/memcached/homebrew.mxcl.memcached.plist ~/Library/LaunchAgents
-  launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.memcached.plist
-  ```
-
-### Install Ruby and Bundler
-
-* Use a Ruby version manager (choose one)
-  * [chruby](https://github.com/postmodern/chruby) and [ruby-install](https://github.com/postmodern/ruby-install)
-  * [rvm](http://rvm.io/)
-  * [rbenv](https://github.com/rbenv/rbenv)
-* Required Minimum Ruby version is 2.3.1+
-* Required Minimum Bundler version is 1.8.7+
-
-### Setup Git and Github
-
-* The most reliable authentication mechanism for git uses SSH keys.
-  * [SSH Key Setup](https://help.github.com/articles/generating-ssh-keys) Set up a SSH keypair for authentication.  Note: If you enter a passphrase, you will be prompted every time you authenticate with it.
-* Github account setup [Account Settings](https://github.com/settings).
-  * [Profile](https://github.com/settings/profile): Fill in your personal information, such as your name.
-  * [Profile](https://github.com/settings/profile): Optionally set up an avatar at gravatar.com.  When you set up your gravatar, be sure to have an entry for the addresses you plan to use with git / Github.
-  * [Emails](https://github.com/settings/emails): Enter your e-mail address and verify it, click the Verify button and follow the instructions.
-  * [Notification Center](https://github.com/settings/notifications) / Notification Email / Custom Routing: Change the email address associated with ManageIQ if desired.
-  * If you are a member of the ManageIQ organization:
-    * Go to [the Members page](https://github.com/ManageIQ?tab=members).
-      * Verify you are listed.
-      * Optionally click Publicize Membership.
-* Fork ManageIQ/manageiq:
-  * Go to [ManageIQ/manageiq](https://github.com/ManageIQ/manageiq)
-  * Click the Fork button and choose "Fork to \<yourname\>"
-* Git configuration and default settings.
-
-  ```bash
-  git config --global user.name "Joe Smith"
-  git config --global user.email joe.smith@example.com
-  git config --global --bool pull.rebase true
-  git config --global push.default simple
-  ```
-
-  If you need to use git with other email addresses, you can set the local user.email from within the clone using:
-
-  ```bash
-  git config user.name "Joe Smith"
-  git config user.email joe.smith@example.com
-  ```
-
-### Clone the Code
+Run memcached, exposing port 11211 to the host:
 
 ```bash
-git clone git@github.com:JoeSmith/manageiq.git # Use "-o my_fork" if you don't want the remote to be named origin
-cd manageiq
-git remote add upstream git@github.com:ManageIQ/manageiq.git
-git fetch upstream
+podman run --detach --publish 11211:11211 memcached
 ```
 
-You can add other remotes at any time to collaborate with others by running:
+Run PostgreSQL, exposing port 5432 to the host:
 
 ```bash
-git remote add other_user git@github.com:OtherUser/manageiq.git
-git fetch other_user
+podman run --detach --publish 5432:5432 --env POSTGRES_USER=root postgres
 ```
 
-### Javascripty things
+### Locally
 
-  Make sure your node version is at least the [required version](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/package.json). If not, you can use [nvm](https://github.com/creationix/nvm) to install a node version locally (similar to `rbenv`).
+Install memcached:
 
-  Note: you may need to run the `npm install -g` commands using sudo if you get permission errors,
-  but if your node environment is up to date you should be able to install without sudo.
-  If you do get these errors and you don't want to use sudo,
-  [you can configure npm to install packages globally for a given user](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md).
+* Using dnf: `sudo dnf -y install memcached`
+* Using yum: `sudo yum -y install memcached`
+* Using apt: `sudo apt -y install memcached`
+* Using brew: `brew install memcached`
 
-* Install the _Yarn_ package manager
+Enable and start the service.
 
-  Follow [official instructions](https://yarnpkg.com/lang/en/docs/install/#linux-tab) or
-
-  ```bash
-  npm install -g yarn
-  ```
-
-* Install the _Gulp_ and _Webpack_ build system
-
-  ```bash
-  npm install -g gulp-cli
-  npm install -g webpack
-  ```
-
-### Get the Rails environment up and running
+Using systemd:
 
 ```bash
-bin/setup                  # Installs dependencies, config, prepares database, etc
-bundle exec rake evm:start # Starts the ManageIQ EVM Application in the background
+systemctl enable --now memcached
 ```
 
-* You can now access the application at `http://localhost:3000`. The default username is `admin` with password `smartvm`.
-* There is also a minimal mode available to start the application with fewer services and workers for faster startup or
-targeted end-user testing. See the [minimal mode guide](developer_setup/minimal_mode.md) for details.
-* As an alternative to minimal mode, individual workers can also be started using [Foreman](https://ddollar.github.io/foreman/)
-  * See the [Foreman guide](developer_setup/foreman.md) for details.
-* To run the test suites, see [the guide on that topic](developer_setup/running_test_suites.md).
-
-### Update dependencies and migrate db
-
-* You can update ruby and javascript dependencies as well as run migrations using one command
+Using Homebrew:
 
 ```bash
-bin/update                # Updates dependencies using bundler and bower, runs migrations, prepares test db.
+brew services start memcached
 ```
 
-For provider, UI or other plugin development, see [the guide on that topic](developer_setup/plugins.md).
+Install postgresql:
 
-#### Some troubleshooting notes
+* Using dnf: `sudo dnf -y install postgresql-server`
+* Using yum: `sudo yum -y install postgresql-server`
+* Using apt: `sudo apt -y install postgresql`
+* Using brew: `brew install postgresql`
 
-* First login fails
+Configure, enable and start the service.
 
-Make sure you have memcached running. If not stop the server with `bundle exec rake evm:stop`,
-start memcached and retry.
+Using systemd:
 
-* `bin/setup fails` while trying to load the gem 'sprockets/es6'
-
-If this happens check the log for
-`ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime` a few lines down.
-When this message is present, then the you need to install `node.js` and re-try
-
-* `bin/setup` fails while trying to install the 'nokogiri' gem
-
-If this happens, you may be missing developer tools in your OS X. Try to install them with
-`xcode-select --install` and re-try.
-
-* `bin/setup` fails to install the 'sys-proctable' gem, or installs the wrong version.
-
-If this happens it may be a Bundler issue. Try running `bundle config specific_platform true`
-and re-try.
-
-* Can't install any gems during bundle install
-
-```
-# install all dependencies to a local path
-bundle install --path vendor/bundle
+```bash
+sudo postgresql-setup initdb --auth trust --username root --encoding UTF-8 --locale C
+systemctl enable --now postgres
 ```
 
-* Can't install `nokogiri-1.7.2` on a Mac
+Using Homebrew:
 
-```
-# install dependencies
-brew install pkgconfig
-brew install libxml2
-
-# test the gem can be compiled with the right libxml2
-export PKG_CONFIG_PATH=/usr/local/opt/libxml2/lib/pkgconfig
-gem install nokogiri -v 1.7.2 -- --use-system-libraries
-
-# configure bundle to do so
-bundle config build.nokogiri --use-system-libraries --with-xml2-include=$(brew --prefix libxml2)/include/libxml2
+```bash
+rm -rf /usr/local/var/postgres
+initdb --auth trust --username root --encoding UTF-8 --locale C /usr/local/var/postgres
+brew services start postgresql
 ```
 
-* Can't install `sys-proctable` on a Mac - a package missing even after bundle install succeeded
+## Install nvm and JavaScript build utilities
 
+Yarn, Gulp and Webpack are required to compile JavaScript assets. NodeJS version 10.16.x is required. If your distribution doesn't ship NodeJS 10.x, you can install [nvm](https://github.com/nvm-sh/nvm) and follow the setup steps. Then install `yarn`, `gulp-cli` and `webpack`.
+
+```bash
+nvm install 10
+npm install -g yarn gulp-cli webpack
 ```
-bundle config specific_platform true
+
+## Clone the project
+
+`git clone git@github.com:ManageIQ/manageiq.git`
+
+## Install Ruby and Bundler
+
+A Ruby version manager is *strongly* recommended. Use any one of the following:
+
+* rbenv
+* rvm
+* chruby
+
+Using the Ruby version manager, install `ruby` >= 2.4.0 and < 2.6.0 and `bundler` >= 1.16.
+
+## Configure Project Manually
+
+All the steps below are wrapped inside the `bin/setup` script, but they are outlined here to explain how to completely bootstrap a developer environment. If you've run PostgreSQL in a container, be sure to export the `DATABASE_URL` variable to connect to the container over TCP instead of a UNIX file socket.
+
+```bash
+export DATABASE_URL='posgresql://localhost:5432' # optional, only necessary if PostgreSQL is running in a container
+```
+
+### Create neccessary config files
+
+In order to run the application locally, a few sample config files need to be copied into their appropriate locations.
+
+```bash
+[[ -f "certs/v2_key" ]] || cp "certs/v2_key.dev" "certs/v2_key"
+[[ -f "config/cable.yml" ]] || cp "config/cable.yml.sample" "config/cable.yml"
+[[ -f "config/database.yml" ]] || cp "config/database.pg.yml" "config/database.yml"
+mkdir -p log
+```
+
+### Install Bundler and Gems
+
+---
+**NOTE**
+
+macOS requires platform specific Gems. Run `bundle config specific_platform true` before installing.
+
+---
+
+```bash
+gem install bundler --version 1.16 --conservative
+bundle config specific_platform true # optional for non-macOS platforms
 bundle install
+bundle exec rails update:ui
+bundle exec rails db:create
+bundle exec rails db:migrate
+bundle exec rails db:seed
+bundle exec rails test:vmdb:setup
+bundle exec rails log:clear tmp:clear
 ```
 
-* If everything is hosed after an OSX upgrade
+## Configure Project Automatically
 
-Install xcode developer tools
+```bash
+bin/setup
+```
 
-```xcode-select --install```
+## Start the Application
 
-Uninstall existing ruby version with your version manager
-Reinstall rubies with version manager
+```bash
+bundle exec rails evm:start
+```
+
+The web UI should now be available at `http://localhost:3000`. The default username is `admin` and the default password is `smartvm`.
+
+## Further Reading
+
+* [Minimal Mode](developer_setup/minimal_mode.md) starts the application with fewer services and workers for faster startup or targeted end-user testing.
+* [Individual workers](developer_setup/foreman.md) can be started using [Foreman](https://ddollar.github.io/foreman) directly.
+* [Running the test suites](developer_setup/running_test_suites.md)
+* [Provider, UI and plugin development](developer_setup/plugins.md) describes the plugin and external provider development process.
+* [Git workflow](developer_setup/git_workflow.md) outlines the recommended `git` and GitHub options.

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -151,6 +151,8 @@ cd manageiq
 
 ## Configure Project
 
+A Ruby script called `setup` is available to quickly set up the application. This script installs the required Gems, sets up necessary JavaScript libraries, creates and migrates the database, and finally seeds the database with development content.
+
 ---
 **NOTE**
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -108,9 +108,9 @@ npm install -g yarn gulp-cli webpack
 
 A Ruby version manager is *strongly* recommended. Use any one of the following:
 
-* rbenv
-* rvm
-* chruby
+* [rbenv](https://github.com/rbenv/rbenv)
+* [rvm](http://rvm.io/)
+* [chruby](https://github.com/postmodern/chruby)
 
 Using the Ruby version manager, install `ruby` >= 2.4.0 and < 2.6.0 and `bundler` >= 1.16.
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -2,13 +2,14 @@
 
 ### Requirements Summary
 
-| **Name** | **Version** |
-| -------- | ----------- |
-| Ruby     | 2.4.x       |
-| Rails    | 5.1.x       |
-| Bundler  | 1.16.x      |
-| NodeJS   | 10.16.x     |
-| Python   | 2.7.x       |
+| **Name**   | **Version** |
+| ---------- | ----------- |
+| Ruby       | 2.4.x       |
+| Rails      | 5.1.x       |
+| Bundler    | 1.15.x      |
+| NodeJS     | 10.16.x     |
+| Python     | 2.7.x       |
+| PostgresQL | 10.x        |
 
 ## Build Requirements
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -15,7 +15,7 @@
 In order to compile Ruby, native Gems and native NodeJS modules, GCC and its related utilities are required. Depending on your Linux distribution, package names may vary slightly.
 
 * Using dnf: `sudo dnf -y install @c-development libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
-* Using yum: `sudo yum -y group install "C Development Tools and Libraries" libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
+* Using yum: `sudo yum -y install @development libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
 * Using apt: `sudo apt -y install build-essential libffi-dev libpq-dev libxml2-dev libcurl-dev cmake libsqlite3-dev python`
 * Using brew: `brew install cmake`
 
@@ -74,13 +74,25 @@ Install postgresql:
 * Using apt: `sudo apt -y install postgresql`
 * Using brew: `brew install postgresql`
 
+---
+**NOTE**
+
+CentOS 7 ships PostgreSQL 9.x. In order to use PostgreSQL 10.x, you will need to [enable Software Collections](https://www.softwarecollections.org/en/docs/) and install `rh-postgresql10`.
+
+```bash
+sudo yum -y uninstall postgresql-devel
+sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postgresql10-postgresql-devel
+```
+
+---
+
 Configure, enable and start the service.
 
 Using systemd:
 
 ```bash
-su -c postgres 'initdb --auth trust --username root --encoding UTF-8 --locale C /var/lib/pgsql/data'
-systemctl enable --now postgres
+sudo PGSETUP_INITDB_OPTIONS='--auth trust --username root --encoding UTF-8 --locale C' postgresql-setup --initdb
+systemctl enable --now postgresql
 ```
 
 Using Homebrew:

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -16,14 +16,14 @@ In order to compile Ruby, native Gems and native NodeJS modules, GCC and its rel
 
 * Using dnf: `sudo dnf -y install @c-development libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
 * Using yum: `sudo yum -y install @development libffi-devel postgresql-devel libxml2-devel libcurl-devel cmake sqlite-devel python`
-* Using apt: `sudo apt -y install build-essential libffi-dev libpq-dev libxml2-dev libcurl-dev cmake libsqlite3-dev python`
+* Using apt: `sudo apt -y install build-essential libffi-dev libpq-dev libxml2-dev libcurl4-openssl-dev cmake libsqlite3-dev python`
 * Using brew: `brew install cmake`
 
 To ensure the appropriate extensions are built when Ruby is compiled, install the header files for OpenSSL, readline and zlib.
 
 * Using dnf: `sudo dnf -y install openssl-devel readline-devel zlib-devel`
 * Using yum: `sudo yum -y install openssl-devel readline-devel zlib-devel`
-* Using apt: `sudo apt -y install libssl-dev libreadline-dev libz-dev`
+* Using apt: `sudo apt -y install libssl-dev libreadline-dev zlib1g-dev`
 * Using brew: `brew install openssl`
 
 ## Service Requirements
@@ -86,20 +86,39 @@ sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postg
 
 ---
 
-Configure, enable and start the service.
+Configure the cluster.
+
+On Fedora and CentOS, a cluster can be configured using `postgresql-setup`.
+
+```bash
+sudo PGSETUP_INITDB_OPTIONS='--auth trust --username root --encoding UTF-8 --locale C' postgresql-setup --initdb
+```
+
+On Debian and Ubuntu, a cluster is configured using `pg_createcluster`.
+
+```bash
+sudo pg_dropcluster --stop 10 main
+sudo pg_createcluster -e UTF-8 -l C 10 main -- --auth trust --username root
+```
+
+On macOS, a cluster is configured using `initdb` directly.
+
+```bash
+rm -rf /usr/local/var/postgres
+initdb --auth trust --username root --encoding UTF-8 --locale C /usr/local/var/postgres
+```
+
+Enable and start the service.
 
 Using systemd:
 
 ```bash
-sudo PGSETUP_INITDB_OPTIONS='--auth trust --username root --encoding UTF-8 --locale C' postgresql-setup --initdb
 systemctl enable --now postgresql
 ```
 
 Using Homebrew:
 
 ```bash
-rm -rf /usr/local/var/postgres
-initdb --auth trust --username root --encoding UTF-8 --locale C /usr/local/var/postgres
 brew services start postgresql
 ```
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -88,20 +88,20 @@ sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postg
 
 Configure the cluster.
 
-On Fedora and CentOS, a cluster can be configured using `postgresql-setup`.
+On Fedora and CentOS, configure a cluster using `postgresql-setup`.
 
 ```bash
 sudo PGSETUP_INITDB_OPTIONS='--auth trust --username root --encoding UTF-8 --locale C' postgresql-setup --initdb
 ```
 
-On Debian and Ubuntu, a cluster is configured using `pg_createcluster`.
+On Debian and Ubuntu, configure a cluster using `pg_createcluster`.
 
 ```bash
 sudo pg_dropcluster --stop 10 main
 sudo pg_createcluster -e UTF-8 -l C 10 main -- --auth trust --username root
 ```
 
-On macOS, a cluster is configured using `initdb` directly.
+On macOS, configured a cluster using `initdb` directly.
 
 ```bash
 rm -rf /usr/local/var/postgres

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -80,7 +80,7 @@ Install postgresql:
 CentOS 7 ships PostgreSQL 9.x. In order to use PostgreSQL 10.x, you will need to [enable Software Collections](https://www.softwarecollections.org/en/docs/) and install `rh-postgresql10`.
 
 ```bash
-sudo yum -y uninstall postgresql-devel
+sudo yum -y remove postgresql-devel
 sudo yum -y install rh-postgresql10 rh-postgresql10-postgresql-syspaths rh-postgresql10-postgresql-devel
 ```
 

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -2,6 +2,7 @@
 
 ### Requirements Summary
 
+|         |         |
 | ------- | ------- |
 | Ruby    | 2.4.x   |
 | Rails   | 5.1.x   |

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -2,6 +2,7 @@
 
 ### Requirements Summary
 
+| ------- | ------- |
 | Ruby    | 2.4.x   |
 | Rails   | 5.1.x   |
 | Bundler | 1.16.x  |

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -171,6 +171,8 @@ mkdir -p log
 
 macOS requires platform specific Gems. Run `bundle config specific_platform true` before installing.
 
+CentOS 7 requires the `rh-postgresql10` SCL environment in order to compile the `pq` Gem's native extensions. Run `bundle install` inside the `scl` environment: `scl enable rh-postgresql10 'bundle install'`.
+
 ---
 
 ```bash

--- a/developer_setup/git_workflow.md
+++ b/developer_setup/git_workflow.md
@@ -1,0 +1,46 @@
+# Configuring Git and GitHub
+
+## GitHub Settings
+
+* Enable [SSH keypair authentication](https://help.github.com/articles/generating-ssh-keys). It is *strongly* recommended when cloning and working with git repositories hosted on GitHub.
+* Set up your [GitHub profile](https://github.com/settings/profile), including name, avatar and [email addresses](https://github.com/settings/emails).
+* If you are a [member](https://github.com/ManageIQ?tab=members) of the [ManageIQ organization](https://github.com/ManageIQ), you may opt to publicize your membership.
+
+## Git Configuration
+
+Set global user, push and pull options. If you want to set options on a per-repository basis, omit `--global`.
+
+```bash
+git config --global user.name "Joe Smith"
+git config --global user.email joe.smith@example.com
+git config --global --bool pull.rebase true
+git config --global push.default simple
+```
+
+## Git Workflow
+
+### Fork
+
+Fork [ManageIQ/manageiq](https://github.com/ManageIQ/manageiq) by clicking on the *Fork* button.
+
+### Clone
+
+Once your fork has been created, clone it and create an upstream remote.
+
+```bash
+git clone git@github.com:<username>/manageiq.git
+cd manageiq
+git remote add upstream git@github.com:ManageIQ/manageiq.git
+git fetch upstream
+```
+
+You can pull upstream changes into your local repository using pull.
+
+```bash
+git pull upstream master --ff
+```
+
+### Pull Request
+
+Once your changes are ready, open a [Pull Request](https://github.com/ManageIQ/manageiq/compare) against the upstream project.
+

--- a/writing_guides.md
+++ b/writing_guides.md
@@ -6,6 +6,6 @@ Markdown syntax is supported by many editors including [VIM](http://www.vim.org/
 
 Updates are accepted as Github PRs.
 
-To preview your work in progress localy before making a PR use [Grip](https://github.com/joeyespo/grip).
+To preview your work in progress locally before making a PR use [Grip](https://github.com/joeyespo/grip).
 
 


### PR DESCRIPTION
During my review of the developer setup steps, I took a lot of notes and rewrote the developer guide to reflect the current state of required software and dependencies.

* Many caveats that had been written into the guide over time are no longer applicable, so I dropped them.
* I restructured the order in which the set up steps occur. Hopefully the steps are clear to follow, especially for new contributors.
* I  combined the steps as much as possible, deviating to platform-specific sections only where necessary.
* I dropped the troubleshooting section. I encountered some of them during my review and incorporated the fixes into earlier steps. Others were no longer applicable.
* I factored the `git` and GitHub steps into a separate guide.

I reviewed these steps on Fedora 30 and macOS 10.14, but I would appreciate another pass by someone else with macOS, and someone on Ubuntu/Debian.