### PR TITLE
Rails/HttpStatus - disable cop

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -47,7 +47,8 @@ Rails:
 Rails/FindEach:
   Enabled: false
 Rails/HttpStatus:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: numeric
 Rails/ReadWriteAttribute:
   AutoCorrect: false
 Style/BracesAroundHashParameters:

--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -46,6 +46,8 @@ Rails:
   Enabled: true
 Rails/FindEach:
   Enabled: false
+Rails/HttpStatus:
+  Enabled: false
 Rails/ReadWriteAttribute:
   AutoCorrect: false
 Style/BracesAroundHashParameters:


### PR DESCRIPTION
Proposing to disable the [Rails/HttpStatus](https://rubydoc.info/gems/rubocop/0.69.0/RuboCop/Cop/Rails/HttpStatus) cop

The current setting for the cop is to prefer symbols, which means:

```
# "bad"
render :foo, status: 200
render json: { foo: 'bar' }, status: 200
render plain: 'foo/bar', status: 304
redirect_to root_url, status: 301

# good
render :foo, status: :ok
render json: { foo: 'bar' }, status: :ok
render plain: 'foo/bar', status: :not_modified
redirect_to root_url, status: :moved_permanently
```

I consider the numeric codes more readable and clearer,
but would not go as far as forcing people to use them.

(Translation table between actual status codes and rails symbols: https://guides.rubyonrails.org/layouts_and_rendering.html#the-status-option)

=> just disabling the cop in this PR

Please vote on what you prefer with :+1: or :-1: on this comment. (:+1: means disable the cop, :-1: means `:status => :ok` is the only right way)