### PR TITLE
Revert #137 and enforce no spaces inside hash braces

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -17,7 +17,7 @@ Layout/ExtraSpacing:
 Layout/SpaceBeforeFirstArg:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
+  EnforcedStyle: no_space
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:


### PR DESCRIPTION
As a reviewer, I'd prefer to re-enable this cop for a couple of reasons:
- With it disabled, it is harder to differentiate between a hash and an inline block
- With the cop disabled, it doesn't complain about inconsistencies in leading and trailing spaces like `{:a => 1 }` or `{ :a => 1}`

This change only affects hashes, not in-line blocks and enforces no leading or trailing spaces inside the braces.

Please vote :+1: if you approve of the change or :-1: if you prefer to leave it disabled.  I think there was a lot of unrelated discussion about Arrays, Blocks and String interpolation (which are not controlled by this cop) in #137 which led to confusion.