### PR TITLE
Don't set pull.rebase to true by default

### DIFF
--- a/developer_setup/git_workflow.md
+++ b/developer_setup/git_workflow.md
@@ -13,7 +13,6 @@ Set global user, push and pull options. If you want to set options on a per-repo
 ```bash
 git config --global user.name "Joe Smith"
 git config --global user.email joe.smith@example.com
-git config --global --bool pull.rebase true
 git config --global push.default simple
 ```
 


### PR DESCRIPTION
Rebasing by default requires knowing how to resolve conflicts that arise from rebasing. I know that rebasing can keep commit history clean(er) by keeping out merge commits, but it can make for some complicated working trees that are hard to resolve cleanly.

For new developers, I think it's best if they don't have to learn rebasing techniques at the same time as learning a new project & code base.