### PR TITLE
Add deployment to manageiq.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: bash
+script:
+- "true"
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: curl -sSL https://raw.githubusercontent.com/ManageIQ/manageiq.github.io/build/trigger.sh | bash -s
+  on:
+    branch: master


### PR DESCRIPTION
This PR adds a deployment step to Travis so that a successful merged build will kick a website rebuild via the newer GH pages based manageiq.github.io (which will eventually become manageiq.org)

@bdunne Please review