### PR TITLE
Add methods to be ignored by rubocop

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -93,6 +93,9 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   IgnoredMethods:
     # Ruby
+    - add_dependency
+    - add_development_dependency
+    - add_runtime_dependency
     - alias_method
     - attr_accessor
     - attr_reader


### PR DESCRIPTION
These methods are  usually treated as a DSL and should be ignored
by Style/MethodCallWithArgsParentheses.

See comments in https://github.com/ManageIQ/manageiq-automation_engine/pull/369#discussion_r324851649
for more details.