### PR TITLE
Fix incorrect URL in plugins guide

### DIFF
--- a/developer_setup/plugins.md
+++ b/developer_setup/plugins.md
@@ -185,4 +185,4 @@ git remote rm tmp
 
 ### Creating a new provider (plugin)
 
-If you plan to create a cloud manager type provider, you can use this [provider generator](/providers/generator/generator.md) to scaffold.
+If you plan to create a cloud manager type provider, you can use this [provider generator](/plugins/generator.md) to scaffold.


### PR DESCRIPTION
This will fix the broken link reported in https://github.com/ManageIQ/guides/issues/377.

cc:  @gmcculloug