### PR TITLE
Some parameter names are short but meaningful

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -40,6 +40,10 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   Enabled: false
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - vm
+    - dc
 Performance/Casecmp:
   Enabled: false
 Rails:


### PR DESCRIPTION
Parameters like 'vm' and 'dc' are quite meaningful and often used in
providers so I propose to make an exception to the rule of minimum three
characters length for those.