### PR TITLE
Encourage regular numeric comparisons

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -234,7 +234,7 @@ Style/MethodCallWithArgsParentheses:
 Style/NumericLiterals:
   AutoCorrect: false
 Style/NumericPredicate:
-  AutoCorrect: false
+  Enabled: false
 Style/PerlBackrefs:
   Enabled: false
 Style/ParallelAssignment:


### PR DESCRIPTION
Don't suggest `i.positive?`
Allow `i > 0`

Alternative would be to push using numeric comparison:

```yaml
Style/NumericPredicate:
  AutoCorrect: false
  EnforcedStyle: comparison
```

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericPredicate

Please guide me if I did this wrong (this is my first run in with the cops)

EDIT by @Fryguy: Please vote with

- :+1: if you want to enforce `comparison` (`i > 0` only)
- :-1: if you want to keep it the way it is, and enforce `predicate` (`i.positive?` only)
- :rocket: if you want it `disabled` (both are allowed)