### PR TITLE
Rename cops to use updated names

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -5,7 +5,7 @@ AllCops:
     - spec/manageiq/**/*
     - vendor/**/*
   TargetRubyVersion: 2.5
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 Layout/DefEndAlignment:
@@ -40,7 +40,7 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   AllowedNames:
     - vm
     - dc


### PR DESCRIPTION
Fixes this thing:

``` ruby
Error: The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml, please update it)
The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml, please update it)
```

see https://github.com/rubocop-hq/rubocop/issues/7077#issuecomment-546317645