### PR TITLE
Update ruby version to 2.5

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -4,7 +4,7 @@
 
 | **Name**   | **Version** |
 | ---------- | ----------- |
-| Ruby       | 2.4.x       |
+| Ruby       | 2.5.x       |
 | Rails      | 5.1.x       |
 | Bundler    | 1.15.x      |
 | NodeJS     | 10.16.x     |


### PR DESCRIPTION
thanks @mturley 

developers should now be using Ruby 2.5.x

Fixes https://github.com/ManageIQ/guides/issues/371