### PR TITLE
Remote consoles - add steps to enable WebMKS

### DIFF
--- a/ui/remote_consoles.md
+++ b/ui/remote_consoles.md
@@ -4,9 +4,12 @@ ManageIQ includes 3rd party HTML5/Javascript implementation of VNC and SPICE rem
 
 The VNC (or SPICE) data is wrapped into web socket protocol and SSL (wss://). The proxy is implemented as a separate ManageIQ worker and on an appliance it runs behind Apache on port 443 together with the rest of the UI (worker, static assets, SUI) as well as the API.
 
-Remote consoles are also supported for OpenStack but OpenStack includes it's own HTML5/Javascript clients and ManageIQ just openes URL provided by OpenStack API. Therefor ManageIQ does not do any tunelling or proxying for the OpenStack consoles.
+Remote consoles are also supported for OpenStack but OpenStack includes it's own HTML5/Javascript clients and ManageIQ just opens URL provided by OpenStack API. Therefore ManageIQ does not do any tunelling or proxying for the OpenStack consoles.
 
 
 In some deployment scenarios the appliance running the UI role does not have the visibility to the hypervisors that expose the VNC/SPICE endpoints. For this case ManageIQ includes an option for a 2nd level proxy.
 
 In the 2nd level proxy scenario the websocket worker connects to a backend appliance that runs a `socat` process that forwards the TCP connection to the hypervisor.
+
+
+WebMKS consoles are supported, but we can not distribute the code needed for that. Therefore, for webmks support, it is first necessary to download the relevant SDK from the official site, and to manually put `wmks.min.js` and `wmks-all.css` into a (new) `/var/www/miq/vmdb/public/webmks/` directory on the appliance.


### PR DESCRIPTION
Comes from a gitter discussion :point_up: [January 15, 2020 5:18 PM](https://gitter.im/ManageIQ/manageiq?at=5e1f497c51fcd0256c92df11),

webmks consoles won't work without the webmks implementation from a vmware sdk, with unclear (or nonexistent?) license, which we can't distribute. But that bit doesn't seem to be documented :).

(I think the current link is https://www.vmware.com/support/developer/html-console/, but not sure whether to have such a link in the documentation.)

(also relevant https://github.com/ManageIQ/manageiq-ui-classic/pull/5044)

Cc @martinpovolny , @skateman 