### PR TITLE
Link different example form for provider plugin toolbars

### DIFF
--- a/ui/provider_plugin.md
+++ b/ui/provider_plugin.md
@@ -73,7 +73,7 @@ It's recommended that the React class be split into two parts:
 
 This is shown in the examples here:
 
-* [Form Example](https://github.com/ManageIQ/react-ui-components/tree/master/src/amazon-security-form-group)
+* [Form Example](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/251)
 * [Using Redux](https://github.com/ManageIQ/manageiq-ui-classic/pull/3509)
 
 #### Dialog player forms


### PR DESCRIPTION
The form referenced as an example for provider plugin toolbar forms was deleted in https://github.com/ManageIQ/react-ui-components/pull/170 beacuse it was never used.

Changing the link to a real, used example from manageiq-providers-lenovo.

Fixes #402