### PR TITLE
developer_setup: remove gulp-cli and global webpack, add yarn install link

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -132,11 +132,16 @@ brew services start postgresql
 
 ## Install nvm and JavaScript build utilities
 
-Yarn, Gulp and Webpack are required to compile JavaScript assets. NodeJS version 10.16.x is required. If your distribution doesn't ship NodeJS 10.x, you can install [nvm](https://github.com/nvm-sh/nvm) and follow the setup steps (you will need to restart your shell in order to source the nvm initialization environment). Then install `yarn`, `gulp-cli` and `webpack`.
+Yarn and NodeJS version 10 or newer are required. If your distribution doesn't ship NodeJS 10.x, you can install [nvm](https://github.com/nvm-sh/nvm) and follow the setup steps (you will need to restart your shell in order to source the nvm initialization environment).
 
 ```bash
 nvm install 10
-npm install -g yarn gulp-cli webpack
+```
+
+Then install `yarn` - you can find the recommended way for your platform at https://classic.yarnpkg.com/en/docs/install, or, if that fails, via npm.
+
+```bash
+npm install -g yarn
 ```
 
 ## Install Ruby and Bundler


### PR DESCRIPTION
`gulp-cli` was needed globally to build SUI, dropped in ManageIQ/manageiq-ui-service#719.
`webpack` was needed globally before the advent of `webpack-cli`, +- https://github.com/ManageIQ/manageiq-ui-classic/pull/3776.

`yarn` can still be installed via `npm install -g yarn`, but it's not *the* recommended way of doing that, adding a link to https://classic.yarnpkg.com/en/docs/install/.

Also a slight rewording to *not* sound like we need node 10.16 exactly, node 12 is supported since ManageIQ/manageiq-ui-classic#6008 (and node 14 *should* work with master too).