### PR TITLE
Add instructions for adding CodeReady Containers

### DIFF
--- a/providers/openshift.md
+++ b/providers/openshift.md
@@ -67,7 +67,7 @@ $ ansible-playbook playbooks/byo/config.yml -i path/to/inventory/file
 
 For a simple single host setup for working with the openshift provider locally,
 you can use [`minishift`](https://github.com/minishift/minishift) to run a
-local openshift instance.
+local openshift 3.x instance.
 
 
 #### Requirements
@@ -136,14 +136,88 @@ regardless of the hypervisor).
    
    Or through the UI if you prefer.
 
+
+### Running with CodeReady Containers
+
+
+If you want to develop with an OpenShift 4 provider, CodeReady Containers (CRC)
+is a great option.  It provides all of benefits as minishift (a simple single
+vm openshift on your development machine) but is an OpenShift v4 cluster.
+
+
+#### Requirements
+
+* [`CodeReady Containers`](https://github.com/code-ready/crc) ([Installation Instructions](https://code-ready.github.io/crc/#installation_gsg))
+* A compatible [Operating System](https://code-ready.github.io/crc/#minimum-system-requirements-operating-system_gsg) and the [Required software packages](https://code-ready.github.io/crc/#required-software-packages_gsg)
+
+#### Quickstart
+
+1. [Download](https://cloud.redhat.com/openshift/install/crc/installer-provisioned) ane extract the latest release of CRC
+
+    ```console
+    tar xfJ crc-linux-amd64.tar.xz
+    ```
+2. Copy the crc binary to a location on your PATH
+
+    ```console
+    sudo cp crc-linux-1.8.0-amd64/crc /usr/local/bin
+    which crc
+    /usr/local/bin/crc
+    ```
+
+3. Setup and start CRC (it will ask for an image pull secret which you can get from [cloud.redhat.com](https://cloud.redhat.com/openshift/install/crc/installer-provisioned))
+
+    ```console
+    crc setup
+    INFO Checking if oc binary is cached
+    ...
+
+    Setup is complete, you can now run 'crc start' to start the OpenShift cluster
+    crc start
+    ...
+    ? Image pull secret [? for help]
+    ```
+
+4. Login to the cluster with `oc`, the command will be printed when `crc start` finishes or you can call `crc console --credentials`
+    ```console
+    crc console --credentials
+    oc login -u kubeadmin -p KUBEADMING_PASSWORD https://api.crc.testing:6443
+    ```
+
+5. Now you can setup the management-infra/management-admin service account for use with ManageIQ
+    ```console
+    git clone https://gist.github.com/e2fac8be87ea0e9f429b6f5d75e02176 /tmp/manageiq_crc
+    oc adm new-project management-infra --description="Management-Infrastructure"
+    oc create serviceaccount management-admin -n management-infra
+    oc create -f /tmp/manageiq_crc/management-infra-admin-cluster-role.json
+    oc policy add-role-to-user -n management-infra admin -z management-admin
+    oc policy add-role-to-user -n management-infra management-infra-admin -z management-admin
+    oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:management-infra:management-admin
+    oc adm policy add-scc-to-user privileged system:serviceaccount:management-infra:management-admin
+    oc adm policy add-cluster-role-to-user system:image-puller system:serviceaccount:management-infra:inspector-admin
+    oc adm policy add-scc-to-user privileged system:serviceaccount:management-infra:inspector-admin
+    oc adm policy add-cluster-role-to-user self-provisioner system:serviceaccount:management-infra:management-admin
+    ```
+
+6. Grab the console IP address and token to acess CRC through `ManageIQ`
+    ```console
+    cluster_ip=$(crc ip)
+    service_account_token=$(oc sa get-token -n management-infra management-admin)
+    ```
+
+7. Configure a provider in ManageIQ
+    ```console
+    rails r "ManageIQ::Providers::Openshift::ContainerManager.create!(:name => 'CRC', :hostname => '$cluster_ip', :port => 6443, :zone => Zone.visible.first, :security_protocol => 'ssl-without-validation').update_authentication(:bearer => {:auth_key => '$service_account_token'})"
+    ```
+
 ### Automated script to record new VCR
 
 https://github.com/ManageIQ/manageiq-providers-openshift/pull/75 added a script that creates things from template, records 1st vcr, deletes some things, records 2nd.
 
 Currently if you want to copy VCR to manageiq-providers-kubernetes, the spec there assumes Hawkular metrics were running.
 
-- Easiest to use script with minishift.  
-  Have `minishift` in your PATH.
+- Easiest to use script with minishift/crc.  
+  Have `minishift` or `crc` in your PATH.
   As described above, including manageiq addon.  Don't need `--metrics`.
 
 - Alternatively bring your own openshift.


### PR DESCRIPTION
Add instructions for using CodeReady Containers as a local OpenShift 4 provider.

Support for OpenShift 4/CRC was added in https://github.com/ManageIQ/manageiq-providers-openshift/pull/164