### PR TITLE
`tx push --source` uses the `.tx/config` file to determine the message catalog file name

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -311,7 +311,7 @@ locale/manageiq.pot
 
 ```sh
 $ cd locale
-$ tx push --source source
+$ tx push --source
 ```
 
 Now translators in Transifex will have the latest stuff to translate available.
@@ -356,7 +356,7 @@ $ gulp gettext-extract
 * Upload the catalogs to [Transifex](https://www.transifex.com/):
 
 ```sh
-$ tx push --source source
+$ tx push --source
 ```
 
 * Once the translations are complete, download the translated catalogs:


### PR DESCRIPTION
As an example, [this](https://github.com/ManageIQ/manageiq/blob/master/.tx/config#L6) is the message catalog in the [manageiq](https://github.com/ManageIQ/manageiq) repo.