### PR TITLE
Stop RuboCop complaining about `id` as an uncommunicative argument

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -42,8 +42,9 @@ Naming/RescuedExceptionsVariableName:
   Enabled: false
 Naming/UncommunicativeMethodParamName:
   AllowedNames:
-    - vm
+    - id
     - dc
+    - vm
 Performance/Casecmp:
   Enabled: false
 Rails:


### PR DESCRIPTION
This can be super annoying when doing anything in the API :exploding_head: 