### PR TITLE
After pg_createcluster postgres isn't running

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -107,6 +107,7 @@ On Debian and Ubuntu, configure a cluster using `pg_createcluster`.
 ```bash
 sudo pg_dropcluster --stop 10 main
 sudo pg_createcluster -e UTF-8 -l C 10 main -- --auth trust --username root
+sudo pg_ctlcluster 10 main start
 ```
 
 On macOS, configure a cluster using `initdb` directly.


### PR DESCRIPTION
After the `pg_createcluster` command the database isn't automatically started so without also running `pg_ctlcluster 10 main start` it cannot be connected to.

```
Success. You can now start the database server using:

    pg_ctlcluster 13 main start

Ver Cluster Port Status Owner    Data directory              Log file
13  main    5432 down   postgres /var/lib/postgresql/13/main C
```