### PR TITLE
Updated translation documentation

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -57,7 +57,7 @@ Unlike Ruby / HAML sources, JavaScript uses `__()` *(i.e. two underscores rather
 The gettext routines supported in JavaScript sources:
 
 * `__(msgid)`
-* `n_(msgid, msgid_plural, n)`
+* `n__(msgid, msgid_plural, n)`
 * `s_(msgid)`
 
 The semantic is similar to the Ruby equivalents.


### PR DESCRIPTION
Updated translation documentation to correct javascript plural translation from `n_` to `n__`.