### PR TITLE
Updating max versions for Node and PostgreSQL

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -6,9 +6,9 @@
 | ---------- | --------------- | --------------- |
 | Ruby       | 2.7.x           | 3.0.x           |
 | Bundler    | 2.1.4           | 2.x             |
-| NodeJS     | 14.x.x          |                 |
+| NodeJS     | 14.x.x          | 14.x.x          |
 | Python     | 3.8.x           |                 |
-| PostgreSQL | 10.x            | 12.x            |
+| PostgreSQL | 10.x            | 13.x            |
 
 ## Prerequisites
 


### PR DESCRIPTION
Running into issues setting up a new dev env from zero (on Mac M1). @Fryguy gave me the supported version range for NodeJS.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>