### PR TITLE
Do not specify the locale when creating a database

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -85,7 +85,7 @@ ManageIQ requires a memcached instance for session caching and a PostgreSQL data
    * Fedora / CentOS
 
      ```bash
-     sudo PGSETUP_INITDB_OPTIONS='--auth trust --username root --encoding UTF-8 --locale C' postgresql-setup --initdb
+     sudo PGSETUP_INITDB_OPTIONS='--auth trust --username root --encoding UTF-8' postgresql-setup --initdb
      ```
 
    * Debian / Ubuntu
@@ -110,7 +110,7 @@ ManageIQ requires a memcached instance for session caching and a PostgreSQL data
 
      ```bash
      rm -rf /usr/local/var/postgres
-     initdb --auth trust --username root --encoding UTF-8 --locale C /usr/local/var/postgres
+     initdb --auth trust --username root --encoding UTF-8 /usr/local/var/postgres
      ```
 
    * containers


### PR DESCRIPTION
We currently do not specify the locale when creating our pod or appliance database So lets not set the locale for our development database.

Most mac developers use the default mac install, which takes the locale from the environment (`en_US`) and doesn't pass it in.

