### PR TITLE
Improve the "Next Steps" section of writing_a_new_provider

### DIFF
--- a/providers/writing_a_new_provider.md
+++ b/providers/writing_a_new_provider.md
@@ -555,8 +555,9 @@ That's a very high level overview of writing a provider.  There is a lot still t
 * Add more collections like cloud_volumes and cloud_tenants to your CloudManager
 * Add a NetworkManager and start collecting CloudNetworks, CloudSubnets, etc...
 * Add some [operations](create_operation.md) like start/stop/destroy to Vms
-* Add [Targeted Refresh](targeted_refresh.md) and Event and Metrics collection
-* Instance Provisioning
+* Add [Targeted Refresh](targeted_refresh.md) and [Events](events.md) collection to speed up discovery of new inventory
+* Add Metrics collection to show resource utilization and enable better chargeback reports
+* Add Instance Provisioning allowing users to provision services on their own
 * Add a [New Model](adding_a_new_model.md) and collecting it from your provider
 
 Having VMs in inventory is a great start to using some of the other features of ManageIQ and is usually the point where we will accept a new provider into the ManageIQ organization.


### PR DESCRIPTION
I noticed the `events.md` document wasn't traversable from the main `writing_a_new_provider.md` document