### PR TITLE
Add manageiq user to allowed_uids for sssd

### DIFF
--- a/external_auth/ipa-configuration.md
+++ b/external_auth/ipa-configuration.md
@@ -95,7 +95,7 @@ to include ", ifp":
 
 ```
 [ifp]
-  allowed_uids = apache, root
+  allowed_uids = apache, root, manageiq
   user_attributes = +mail, +givenname, +sn, +displayname
 ```
 


### PR DESCRIPTION
When we moved to using a manageiq user, we need to add this user so it has permission in sssd.conf.

See also:
https://github.com/ManageIQ/manageiq/pull/22715
https://github.com/ManageIQ/httpd_configmap_generator/pull/77
https://github.com/ManageIQ/manageiq-documentation/pull/1743
https://github.com/ManageIQ/manageiq-appliance_console/pull/220