### PR TITLE
Update writing_a_new_provider to use config/regions.yml

### DIFF
--- a/providers/writing_a_new_provider.md
+++ b/providers/writing_a_new_provider.md
@@ -344,24 +344,24 @@ class ManageIQ::Providers::AwesomeCloud::CloudManager < ManageIQ::Providers::Clo
 end
 ```
 
-```
-module ManageIQ::Providers::AwesomeCloud::Regions
-  REGIONS = {
-    "us-east-1" => {:name => "us-east-1", :hostname => "us-east-1.awesome.cloud"}
-  }.freeze
-
-  def self.regions
-    REGIONS
-  end
-
-  def self.all
-    regions.values
-  end
-
-  def self.names
-    regions.keys
+Now create a `app/models/manageiq/providers/awesome_cloud/regions.rb`
+```ruby
+module ManageIQ
+  module Providers::AwesomeCloud
+    class Regions < ManageIQ::Providers::Regions
+    end
   end
 end
+```
+
+And a `config/regions.yml`
+
+```yml
+---
+us-east-1:
+  :name: us-east-1
+  :hostname: us-east-1.awesome.cloud
+  :description: US East 1
 ```
 
 With that added you should be able to go to the UI, add a cloud provider, and see your new cloud type.  For development typically the best way to test code in the UI is to run a rails server and a simulated generic worker via the terminal.


### PR DESCRIPTION
We now have better support in core for `Regions` that use a `config/regions.yml` file, update the writing_a_new_provider to use this.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
