### PR TITLE
[WIP] Use Rails credentials instead of deprecated and removed secrets

### DIFF
--- a/developer_setup/seeding_test_inventory.md
+++ b/developer_setup/seeding_test_inventory.md
@@ -39,7 +39,7 @@ ems = ManageIQ::Providers::Amazon::CloudManager.create!(
 We can find these values by looking at the amazon provider's vcr cassette file,
 `src/manageiq/manageiq-providers-amazon/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_inventory_object.yml`
 
-We can see that `'us-east-1'` is used as the region in the URIs, and in the `config/secrets.defaults.yml`
+We can see that `'us-east-1'` is used as the region in the URIs, and in the Rails credentials
 and `spec/factories/ext_management_system.rb` files we can see that `AMAZON_CLIENT_ID` and
 `AMAZON_CLIENT_SECRET` are used for the userid and password values for the authentication.
 

--- a/providers/subclassing_an_existing_provider.md
+++ b/providers/subclassing_an_existing_provider.md
@@ -36,7 +36,6 @@ Initialized empty Git repository in /home/grare/adam/src/manageiq/manageiq/plugi
       create  bin/update
       create  bundler.d
       create  bundler.d/.keep
-      create  config/secrets.defaults.yml
       create  config/settings.yml
       create  lib/manageiq-providers-awesome_private_cloud.rb
       create  lib/manageiq/providers/awesome_private_cloud/engine.rb


### PR DESCRIPTION
Rails 7.1 removes access to modifying secrets as we should be moved over to rails credentials.  Here we describe how to setup these rails crednetials for the purpose of recording VCR cassettes.

See also: https://github.com/ManageIQ/manageiq-providers-autosde/pull/253

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
