### PR TITLE
Add instructions for Fedora 41+ openssl-devel-engine

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -34,6 +34,7 @@
    | apt  | `sudo apt -y install build-essential libffi-dev libpq-dev libxml2-dev libcurl4-openssl-dev cmake python libssh2-1-dev` |
    | brew | `brew install cmake libssh2 iproute2mac` |
 
+   On Fedora 41+  you have to also run `sudo dnf install -y openssl-devel-engine`
    On the mac, `iproute2mac` provides the `ip` command for `appliance_console`.
 
    **Note**: Users with MacOS running on Apple M1 CPU might need to specify location of the `Homebrew` libraries explicitly.


### PR DESCRIPTION
Fix errors installing the rdkfaka gem while compiling the librdkafka library due to missing openssl/engine.h header file.

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/agrare/.gem/ruby/3.1.4/gems/rdkafka-0.19.0/ext
/home/agrare/.rubies/ruby-3.1.4/bin/ruby -I/home/agrare/.rubies/ruby-3.1.4/lib/ruby/3.1.0 -rrubygems
/home/agrare/.gem/ruby/3.1.4/gems/rake-13.2.1/exe/rake
RUBYARCHDIR\=/home/agrare/.gem/ruby/3.1.4/extensions/x86_64-linux/3.1.0-static/rdkafka-0.19.0
RUBYLIBDIR\=/home/agrare/.gem/ruby/3.1.4/extensions/x86_64-linux/3.1.0-static/rdkafka-0.19.0
Extracting librdkafka_2.5.3.tar.gz into tmp/x86_64-redhat-linux/ports/librdkafka/2.5.3... OK
Running git apply with /home/agrare/.gem/ruby/3.1.4/gems/rdkafka-0.19.0/dist/patches/rdkafka_sticky_assignor.c.patch... OK
Running 'configure' for librdkafka 2.5.3... OK
Running 'compile' for librdkafka 2.5.3... ERROR. Please review logs to see what happened:
----- contents of '/home/agrare/.gem/ruby/3.1.4/gems/rdkafka-0.19.0/ext/tmp/x86_64-redhat-linux/ports/librdkafka/2.5.3/compile.log' -----
make[1]: Entering directory
'/home/agrare/.gem/ruby/3.1.4/gems/rdkafka-0.19.0/ext/tmp/x86_64-redhat-linux/ports/librdkafka/2.5.3/librdkafka-2.5.3/src'
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -I. -DWITH_GZFILEOP   -DWITH_GZFILEOP -c rdkafka.c
-o rdkafka.o
In file included from rdkafka_int.h:116,
                 from rdkafka.c:43:
rdkafka_conf.h:40:10: fatal error: openssl/engine.h: No such file or directory
   40 | #include <openssl/engine.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
