### PR TITLE
update proper use of wait_for_task

### DIFF
--- a/ui/queue_wait.md
+++ b/ui/queue_wait.md
@@ -51,8 +51,8 @@ When the task is finished, the `:action` passed in is called with the original p
 
 ```
   def create_finished
-    task_id = session[:async][:params][:task_id]
-    tenant_name = session[:async][:params][:name]
+    task_id = params[:task_id]
+    tenant_name = params[:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
       add_flash(_("%{model} \"%{name}\" created") % {


### PR DESCRIPTION
see also https://github.com/ManageIQ/manageiq-ui-classic/pull/9352

We no longer have session[:async]
Instead we use params (they are taken from the task injected back into the params)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
