### PR TITLE
Bump Ruby minimum to 3.3.1

### DIFF
--- a/developer_setup.md
+++ b/developer_setup.md
@@ -4,7 +4,7 @@
 
 | **Name**   | **Min Version** | **Max Version** |
 | ---------- | --------------- | --------------- |
-| Ruby       | 3.3.x           | 3.4.x           |
+| Ruby       | 3.3.1           | 3.4.x           |
 | Bundler    | 2.5.20          | 4.x             |
 | NodeJS     | 22.22.0         | 22.x.x          |
 | Python     | 3.9.x           |                 |


### PR DESCRIPTION
zeitwerk 2.8.0 causes an error on Ruby 3.3.0 which is fixed in 3.3.1, so we are bumping the minimum

@jrafanie @GilbertCherrie Please review.

Depends on
- https://github.com/ManageIQ/manageiq/pull/23848