### PR TITLE
Fixes from keycloak testing

### DIFF
--- a/external_auth/oidc-httpd-configs/application.conf
+++ b/external_auth/oidc-httpd-configs/application.conf
@@ -22,7 +22,7 @@ Options SymLinksIfOwnerMatch
   Header always unset X-Frame-Options
   Header always set X-Frame-Options "SAMEORIGIN"
   Header always unset Reporting-Endpoints
-  Header always set Reporting-Endpoints "csp-endpoint=\"https://%{HTTP_HOST}i/dashboard/csp_report\""
+  Header always set Reporting-Endpoints "csp-endpoint=\"http://${HTTPD_AUTH_HOST}:${HTTPD_AUTH_PORT}/dashboard/csp_report\""
 
   RewriteCond %{REQUEST_URI}     ^/ws/notifications [NC]
   RewriteCond %{HTTP:UPGRADE}    ^websocket$ [NC]

--- a/external_auth/oidc-httpd-configs/authentication.conf
+++ b/external_auth/oidc-httpd-configs/authentication.conf
@@ -36,7 +36,7 @@ Header always set X-Content-Type-Options "nosniff"
 Header always unset Referrer-Policy
 Header always set Referrer-Policy "no-referrer-when-downgrade"
 Header always unset Reporting-Endpoints
-Header always set Reporting-Endpoints "csp-endpoint=\"https://%{HTTP_HOST}i/dashboard/csp_report\""
+Header always set Reporting-Endpoints "csp-endpoint=\"http://${HTTPD_AUTH_HOST}:${HTTPD_AUTH_PORT}/dashboard/csp_report\""
 
 # CSP for OIDC authentication redirects - allows inline styles/scripts needed by auth flow
 <Location /oidc_login>

--- a/external_auth/oidc.md
+++ b/external_auth/oidc.md
@@ -35,7 +35,7 @@ running an OIDC server and Apache on a local development setup.
      -e HTTPD_AUTH_HOST=127.0.0.1.nip.io \
      -e HTTPD_AUTH_PORT=8080 \
      --add-host=127.0.0.1.nip.io:192.168.127.254 \
-     manageiq/httpd:latest
+     manageiq/httpd:2-el10
    ```
    Note: 192.168.65.2 / 192.168.127.254 is a hardcoded proxy for host.docker.internal / host.containers.internal on docker / podman
 


### PR DESCRIPTION
### Fix Reporting-Endpoints hostname in OIDC httpd configs

    %{HTTP_HOST}i fails to expand correctly in manageiq/httpd:2-el10_2.1
    at the VirtualHost Header always set level, producing a broken URL
    like 'i=99' instead of the actual hostname.

    Replace with the HTTPD_AUTH_HOST and HTTPD_AUTH_PORT env vars that are
    already passed to the container at startup, matching the pattern used
    for ServerName and OIDCRedirectURI elsewhere in these configs.

    Verified using the Keycloak + httpd + local Rails dev setup described
    in oidc.md -- Reporting-Endpoints now renders the correct hostname.

    Followup to c3e6e8c which introduced the Reporting-Endpoints header.

### Pin httpd image to manageiq/httpd:2-el10

    The guides were updated to use OIDCPassClaimsAs both none (6cdcde2)
    which requires a newer mod_auth_openidc. The older base OS image ships
    an older mod_auth_openidc that does not support this directive; the
    el10-based image does.