### PR TITLE
Keep guides synchronized with pods/appliance configuration

### DIFF
--- a/external_auth/oidc-httpd-configs/application.conf
+++ b/external_auth/oidc-httpd-configs/application.conf
@@ -13,6 +13,9 @@ Options SymLinksIfOwnerMatch
   ProxyPreserveHost on
   RequestHeader set Host ${HTTPD_AUTH_HOST}:${HTTPD_AUTH_PORT}
   RequestHeader set X-Forwarded-Host ${HTTPD_AUTH_HOST}:${HTTPD_AUTH_PORT}
+  # For consistent headers we set for pods or appliances, add commented X-Forwarded-Proto
+  # even though local setup with keycloak OIDC currently uses http.
+  # RequestHeader set X-Forwarded-Proto 'https'
   Header always unset Strict-Transport-Security
   Header always set Strict-Transport-Security "max-age=631138519"
   Header always unset X-Content-Type-Options


### PR DESCRIPTION
We're adding a commented X-Forwarded-Proto even though local setup with keycloak OIDC currently uses http.

See also:
https://github.com/ManageIQ/manageiq-appliance/pull/414 https://github.com/ManageIQ/manageiq-pods/pull/1415

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
